### PR TITLE
PR: feat: Appliance CRUD with pagination, sorting, i18n, and role-based access

### DIFF
--- a/src/main/java/io/github/serhiiklym/appliance_store/controller/ApplianceController.java
+++ b/src/main/java/io/github/serhiiklym/appliance_store/controller/ApplianceController.java
@@ -1,5 +1,83 @@
 package io.github.serhiiklym.appliance_store.controller;
 
+import io.github.serhiiklym.appliance_store.controller.dto.ApplianceForm;
+import io.github.serhiiklym.appliance_store.error.DuplicateApplianceNameException;
+import io.github.serhiiklym.appliance_store.model.Category;
+import io.github.serhiiklym.appliance_store.model.Manufacturer;
+import io.github.serhiiklym.appliance_store.model.PowerType;
+import io.github.serhiiklym.appliance_store.service.ApplianceService;
+import io.github.serhiiklym.appliance_store.service.ManufacturerService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import java.util.List;
+
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+@RequestMapping(path = "/appliances")
 public class ApplianceController {
+
+    private final ApplianceService service;
+    private final ManufacturerService manufacturerService;
+
+    @GetMapping
+    public String list(Model model) {
+        model.addAttribute("appliances", service.list());
+        return "/appliance/appliances";
+    }
+
+    @GetMapping("/add")
+    public String showCreateForm(Model model) {
+        model.addAttribute("form", new ApplianceForm());
+        return "/appliance/newAppliance";
+    }
+
+    @PostMapping
+    public String create(@Valid @ModelAttribute("form") ApplianceForm form,
+                         BindingResult binding,
+                         RedirectAttributes ra){
+        if (binding.hasErrors()) return "/appliance/newAppliance";
+
+        try {
+            service.create(form.getName(), form.getCategory(), form.getModel(), form.getManufacturer(),
+                    form.getPowerType(), form.getCharacteristic(), form.getDescription(),
+                    form.getPower(), form.getPrice());
+        } catch (DuplicateApplianceNameException | DataIntegrityViolationException ex) {
+            binding.rejectValue("name", "appliance.name.duplicate",
+                    new Object[]{form.getName()}, null);
+            return "/appliance/newAppliance"; // stay on page, show inline error
+        }
+        ra.addFlashAttribute("flashSuccess", "Created: " + form.getName());
+        return "redirect:/appliances";
+    }
+
+
+    // Run before every handler method in this controller and adds data to the model (select dropdowns)
+    @ModelAttribute("categories")
+    public Category[] categories() {
+        return Category.values();
+    }
+
+    @ModelAttribute("powerTypes")
+    public PowerType[] powerTypes() {
+        return PowerType.values();
+    }
+
+    @ModelAttribute("manufacturers")
+    public List<Manufacturer> manufacturers() {
+        return manufacturerService.list();
+    }
+
 }
 

--- a/src/main/java/io/github/serhiiklym/appliance_store/controller/ApplianceController.java
+++ b/src/main/java/io/github/serhiiklym/appliance_store/controller/ApplianceController.java
@@ -26,7 +26,7 @@ import java.util.List;
 @Controller
 @RequiredArgsConstructor
 @RequestMapping(path = "/appliances")
-public class ApplianceController {
+public class ApplianceController extends BaseController {
 
     private final ApplianceService service;
     private final ManufacturerService manufacturerService;
@@ -40,25 +40,24 @@ public class ApplianceController {
     @GetMapping("/add")
     public String showCreateForm(Model model) {
         model.addAttribute("form", new ApplianceForm());
-        return "/appliance/newAppliance";
+        return "appliance/newAppliance";
     }
 
     @PostMapping
     public String create(@Valid @ModelAttribute("form") ApplianceForm form,
                          BindingResult binding,
-                         RedirectAttributes ra){
-        if (binding.hasErrors()) return "/appliance/newAppliance";
+                         RedirectAttributes ra) {
+        if (binding.hasErrors()) return "appliance/newAppliance";
 
         try {
             service.create(form.getName(), form.getCategory(), form.getModel(), form.getManufacturer(),
                     form.getPowerType(), form.getCharacteristic(), form.getDescription(),
                     form.getPower(), form.getPrice());
         } catch (DuplicateApplianceNameException | DataIntegrityViolationException ex) {
-            binding.rejectValue("name", "appliance.name.duplicate",
-                    new Object[]{form.getName()}, null);
-            return "/appliance/newAppliance"; // stay on page, show inline error
+            flashErrorCode(ra, "appliance.name.duplicate", form.getName());
+            return "appliance/newAppliance"; // stay on page, show inline error
         }
-        ra.addFlashAttribute("flashSuccess", "Created: " + form.getName());
+        flashSuccess(ra, "appliance.created");
         return "redirect:/appliances";
     }
 
@@ -95,7 +94,7 @@ public class ApplianceController {
         // Update ONLY the editable fields
         service.update(id, form.getModel(), form.getCharacteristic(), form.getDescription(), form.getPrice());
 
-        ra.addFlashAttribute("flashSuccess", "appliance.msg.updated");
+        flashSuccess(ra, "appliance.updated");
         return "redirect:/appliances";
     }
 
@@ -104,14 +103,13 @@ public class ApplianceController {
         try {
             service.deleteAppliance(id);
             log.info("Deleted Appliance with id={}", id);
-            ra.addFlashAttribute("flashSuccess", "appliance.deleted");
+            flashSuccess(ra, "appliance.deleted");
             return "redirect:/appliances";
         } catch (DataIntegrityViolationException ex) {
-            ra.addFlashAttribute("flashError", "appliance.delete.constraint");
-            ra.addAttribute("id", id); // <-- lets {id} expand in the redirect URL
+            flashErrorCode(ra, "appliance.delete.constraint");
             return "redirect:/appliance/{id}/edit";
         } catch (NotFoundException ex) {
-            ra.addFlashAttribute("flashError", "appliance.notfound");
+            flashErrorText(ra, "appliance.notfound");
             return "redirect:/appliances";
         }
     }

--- a/src/main/java/io/github/serhiiklym/appliance_store/controller/ApplianceController.java
+++ b/src/main/java/io/github/serhiiklym/appliance_store/controller/ApplianceController.java
@@ -1,8 +1,10 @@
 package io.github.serhiiklym.appliance_store.controller;
 
+import io.github.serhiiklym.appliance_store.controller.dto.ApplianceEditForm;
 import io.github.serhiiklym.appliance_store.controller.dto.ApplianceForm;
 import io.github.serhiiklym.appliance_store.controller.dto.ManufacturerForm;
 import io.github.serhiiklym.appliance_store.error.DuplicateApplianceNameException;
+import io.github.serhiiklym.appliance_store.error.NotFoundException;
 import io.github.serhiiklym.appliance_store.model.Category;
 import io.github.serhiiklym.appliance_store.model.Manufacturer;
 import io.github.serhiiklym.appliance_store.model.PowerType;
@@ -79,7 +81,7 @@ public class ApplianceController {
     @PostMapping("/{id}")
     public String update(
             @PathVariable Long id,
-            @Valid @ModelAttribute("form") ApplianceForm form,
+            @Valid @ModelAttribute("form") ApplianceEditForm form,
             BindingResult br,
             Model model,
             RedirectAttributes ra) {
@@ -91,10 +93,27 @@ public class ApplianceController {
         }
 
         // Update ONLY the editable fields
-        service.update(form.getModel(), form.getCharacteristic(), form.getDescription(), form.getPrice());
+        service.update(id, form.getModel(), form.getCharacteristic(), form.getDescription(), form.getPrice());
 
         ra.addFlashAttribute("flashSuccess", "appliance.msg.updated");
         return "redirect:/appliances";
+    }
+
+    @PostMapping("/{id}/delete")
+    public String delete(@PathVariable Long id, RedirectAttributes ra) {
+        try {
+            service.deleteAppliance(id);
+            log.info("Deleted Appliance with id={}", id);
+            ra.addFlashAttribute("flashSuccess", "appliance.deleted");
+            return "redirect:/appliances";
+        } catch (DataIntegrityViolationException ex) {
+            ra.addFlashAttribute("flashError", "appliance.delete.constraint");
+            ra.addAttribute("id", id); // <-- lets {id} expand in the redirect URL
+            return "redirect:/appliance/{id}/edit";
+        } catch (NotFoundException ex) {
+            ra.addFlashAttribute("flashError", "appliance.notfound");
+            return "redirect:/appliances";
+        }
     }
 
 

--- a/src/main/java/io/github/serhiiklym/appliance_store/controller/ApplianceController.java
+++ b/src/main/java/io/github/serhiiklym/appliance_store/controller/ApplianceController.java
@@ -2,7 +2,6 @@ package io.github.serhiiklym.appliance_store.controller;
 
 import io.github.serhiiklym.appliance_store.controller.dto.ApplianceEditForm;
 import io.github.serhiiklym.appliance_store.controller.dto.ApplianceForm;
-import io.github.serhiiklym.appliance_store.controller.dto.ManufacturerForm;
 import io.github.serhiiklym.appliance_store.error.DuplicateApplianceNameException;
 import io.github.serhiiklym.appliance_store.error.NotFoundException;
 import io.github.serhiiklym.appliance_store.model.Category;
@@ -34,7 +33,7 @@ public class ApplianceController extends BaseController {
     @GetMapping
     public String list(Model model) {
         model.addAttribute("appliances", service.list());
-        return "/appliance/appliances";
+        return "appliance/appliances";
     }
 
     @GetMapping("/add")

--- a/src/main/java/io/github/serhiiklym/appliance_store/controller/ApplianceController.java
+++ b/src/main/java/io/github/serhiiklym/appliance_store/controller/ApplianceController.java
@@ -1,6 +1,7 @@
 package io.github.serhiiklym.appliance_store.controller;
 
 import io.github.serhiiklym.appliance_store.controller.dto.ApplianceForm;
+import io.github.serhiiklym.appliance_store.controller.dto.ManufacturerForm;
 import io.github.serhiiklym.appliance_store.error.DuplicateApplianceNameException;
 import io.github.serhiiklym.appliance_store.model.Category;
 import io.github.serhiiklym.appliance_store.model.Manufacturer;
@@ -14,10 +15,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import java.util.List;
@@ -59,6 +57,43 @@ public class ApplianceController {
             return "/appliance/newAppliance"; // stay on page, show inline error
         }
         ra.addFlashAttribute("flashSuccess", "Created: " + form.getName());
+        return "redirect:/appliances";
+    }
+
+    @GetMapping("/{id}/edit")
+    public String showEditForm(@PathVariable Long id, Model model) {
+        var a = service.getByIdOrThrow(id);
+
+        var form = new ApplianceForm();
+        form.setModel(a.getModel());
+        form.setCharacteristic(a.getCharacteristic());
+        form.setDescription(a.getDescription());
+        form.setPrice(a.getPrice());
+
+        model.addAttribute("id", id);
+        model.addAttribute("form", form);
+        model.addAttribute("appliance", a); // for read-only display
+        return "appliance/editAppliance";
+    }
+
+    @PostMapping("/{id}")
+    public String update(
+            @PathVariable Long id,
+            @Valid @ModelAttribute("form") ApplianceForm form,
+            BindingResult br,
+            Model model,
+            RedirectAttributes ra) {
+
+        if (br.hasErrors()) {
+            model.addAttribute("id", id);
+            model.addAttribute("appliance", service.getByIdOrThrow(id));
+            return "appliance/editAppliance";
+        }
+
+        // Update ONLY the editable fields
+        service.update(form.getModel(), form.getCharacteristic(), form.getDescription(), form.getPrice());
+
+        ra.addFlashAttribute("flashSuccess", "appliance.msg.updated");
         return "redirect:/appliances";
     }
 

--- a/src/main/java/io/github/serhiiklym/appliance_store/controller/BaseController.java
+++ b/src/main/java/io/github/serhiiklym/appliance_store/controller/BaseController.java
@@ -1,0 +1,26 @@
+package io.github.serhiiklym.appliance_store.controller;
+
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+public abstract class BaseController {
+
+    private static final String FLASH_SUCCESS     = "flashSuccess";     // string or i18n code
+    private static final String FLASH_ERROR       = "flashError";       // plain string fallback
+    private static final String FLASH_ERROR_CODE  = "flashErrorCode";   // i18n code
+    private static final String FLASH_ERROR_ARGS  = "flashErrorArgs";   // Object[] for code args
+
+    protected void flashSuccess(RedirectAttributes ra, String messageOrCode) {
+        ra.addFlashAttribute(FLASH_SUCCESS, messageOrCode);
+    }
+
+    protected void flashErrorText(RedirectAttributes ra, String plainText) {
+        ra.addFlashAttribute(FLASH_ERROR, plainText);
+    }
+
+    protected void flashErrorCode(RedirectAttributes ra, String code, Object... args) {
+        ra.addFlashAttribute(FLASH_ERROR_CODE, code);
+        if (args != null && args.length > 0) {
+            ra.addFlashAttribute(FLASH_ERROR_ARGS, args);
+        }
+    }
+}

--- a/src/main/java/io/github/serhiiklym/appliance_store/controller/ManufacturerController.java
+++ b/src/main/java/io/github/serhiiklym/appliance_store/controller/ManufacturerController.java
@@ -29,19 +29,12 @@ public class ManufacturerController {
         return "manufacturer/manufacturers";
     }
 
-    @GetMapping("/{id}")
-    public String details(Model model, @PathVariable("id") Long id) {
-        model.addAttribute("manufacturer", service.getByIdOrThrow(id));
-        return "manufacturer/manufacturerDetails";
-    }
-
     // GET /manufacturers/new -> create form
     @GetMapping("/new")
     public String showCreateForm(Model model) {
         model.addAttribute("form", new ManufacturerForm());
         return "manufacturer/newManufacturer";
     }
-
 
     // POST /manufacturers -> create then redirect
     @PostMapping
@@ -74,7 +67,6 @@ public class ManufacturerController {
         return "manufacturer/editManufacturer";
     }
 
-
     // POST /manufacturers/{id} -> update then redirect
     @PostMapping("/{id}")
     public String update(@PathVariable Long id,
@@ -83,7 +75,7 @@ public class ManufacturerController {
                          RedirectAttributes ra) {
         if (errors.hasErrors()) return "manufacturer/editManufacturer";
         try {
-            service.update(id, form.getName()); // or your update method
+            service.update(id, form.getName());
             ra.addFlashAttribute("flashSuccess", "manufacturer.updated");
             return "redirect:/manufacturers";
         } catch (ConflictException e) {

--- a/src/main/java/io/github/serhiiklym/appliance_store/controller/ManufacturerController.java
+++ b/src/main/java/io/github/serhiiklym/appliance_store/controller/ManufacturerController.java
@@ -19,7 +19,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 @Controller
 @RequiredArgsConstructor
 @RequestMapping(path = "/manufacturers")
-public class ManufacturerController {
+public class ManufacturerController extends BaseController {
 
     private final ManufacturerService service;
 
@@ -45,14 +45,11 @@ public class ManufacturerController {
 
         try {
             service.create(form.getName().trim());
-//            ra.addFlashAttribute("flashSuccess", "Manufacturer created: "  + form.getName());
-//            return "redirect:/manufacturers";
         } catch (DuplicateManufacturerNameException | DataIntegrityViolationException ex) {
-            binding.rejectValue("name", "manufacturer.name.duplicate",
-                    new Object[]{form.getName()}, null);
+            flashErrorCode(ra, "manufacturer.name.duplicate", form.getName());
             return "manufacturer/newManufacturer"; // stay on page, show inline error
         }
-        ra.addFlashAttribute("flashSuccess", "Created: " + form.getName());
+        flashSuccess(ra, "manufacturer.created");
         return "redirect:/manufacturers";
     }
 
@@ -76,10 +73,10 @@ public class ManufacturerController {
         if (errors.hasErrors()) return "manufacturer/editManufacturer";
         try {
             service.update(id, form.getName());
-            ra.addFlashAttribute("flashSuccess", "manufacturer.updated");
+            flashSuccess(ra, "manufacturer.updated");
             return "redirect:/manufacturers";
         } catch (ConflictException e) {
-            errors.rejectValue("name", "duplicate", e.getMessage());
+            flashErrorText(ra, "general.error.manufacturer");
             return "manufacturer/editManufacturer";
         }
     }
@@ -90,15 +87,15 @@ public class ManufacturerController {
         try {
             service.deleteManufacturer(id);
             log.info("Deleted manufacturer id={}", id);
-            ra.addFlashAttribute("flashSuccess", "manufacturer.deleted");
+            flashSuccess(ra, "manufacturer.deleted");
             return "redirect:/manufacturers";
         } catch (DataIntegrityViolationException ex) {
             // there are appliances linked to this brand
-            ra.addFlashAttribute("flashError", "manufacturer.delete.constraint");
             ra.addAttribute("id", id); // <-- lets {id} expand in the redirect URL
+            flashErrorText(ra, "manufacturer.delete.constraint");
             return "redirect:/manufacturers/{id}/edit";
         } catch (NotFoundException ex) {
-            ra.addFlashAttribute("flashError", "manufacturer.notfound");
+            flashErrorText(ra, "manufacturer.notfound");
             return "redirect:/manufacturers";
         }
     }

--- a/src/main/java/io/github/serhiiklym/appliance_store/controller/dto/ApplianceEditForm.java
+++ b/src/main/java/io/github/serhiiklym/appliance_store/controller/dto/ApplianceEditForm.java
@@ -1,0 +1,28 @@
+package io.github.serhiiklym.appliance_store.controller.dto;
+
+import jakarta.validation.constraints.*;
+import lombok.Data;
+
+import java.math.BigDecimal;
+
+/**
+ * Minimal form object for update Appliance.
+ */
+@Data
+public class ApplianceEditForm {
+
+    @Size(max = 30, message = "{appliance.model.max}")
+    private String model;
+
+    @Size(max = 300, message = "{appliance.description.max}")
+    private String description;
+
+    @Size(max = 100, message = "{appliance.characteristic.max}")
+    private String characteristic;
+
+    @NotNull(message = "{appliance.price.required}")
+    @Positive(message = "{appliance.price.positive}")
+    @Digits(integer = 9, fraction = 2, message = "{appliance.price.digits}")
+    private BigDecimal price;
+
+}

--- a/src/main/java/io/github/serhiiklym/appliance_store/controller/dto/ApplianceForm.java
+++ b/src/main/java/io/github/serhiiklym/appliance_store/controller/dto/ApplianceForm.java
@@ -1,6 +1,7 @@
 package io.github.serhiiklym.appliance_store.controller.dto;
 
 import io.github.serhiiklym.appliance_store.model.Category;
+import io.github.serhiiklym.appliance_store.model.Manufacturer;
 import io.github.serhiiklym.appliance_store.model.PowerType;
 import jakarta.validation.constraints.*;
 import lombok.Data;
@@ -20,8 +21,7 @@ public class ApplianceForm {
     private String name;
 
     @NotNull(message = "{appliance.manufacturer.id.required}")
-    @Min(1)
-    private Long manufacturerId; // select
+    private Manufacturer manufacturer; // select
 
     @NotNull(message = "{appliance.category.required}")
     private Category category; // select
@@ -39,6 +39,7 @@ public class ApplianceForm {
     private String description;
 
     @PositiveOrZero(message = "{appliance.power.nonNegative}")
+    @NotNull(message = "{appliance.power.required}")
     private Integer power;
 
     @NotNull(message = "{appliance.price.required}")

--- a/src/main/java/io/github/serhiiklym/appliance_store/controller/dto/ApplianceForm.java
+++ b/src/main/java/io/github/serhiiklym/appliance_store/controller/dto/ApplianceForm.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 import java.math.BigDecimal;
 
 /**
- * Minimal form object for create/update Appliance.
+ * Minimal form object for create Appliance.
  */
 @Data
 @NoArgsConstructor

--- a/src/main/java/io/github/serhiiklym/appliance_store/controller/dto/ApplianceForm.java
+++ b/src/main/java/io/github/serhiiklym/appliance_store/controller/dto/ApplianceForm.java
@@ -1,0 +1,49 @@
+package io.github.serhiiklym.appliance_store.controller.dto;
+
+import io.github.serhiiklym.appliance_store.model.Category;
+import io.github.serhiiklym.appliance_store.model.PowerType;
+import jakarta.validation.constraints.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+/**
+ * Minimal form object for create/update Appliance.
+ */
+@Data
+@NoArgsConstructor
+public class ApplianceForm {
+
+    @NotBlank(message = "{appliance.name.required}")
+    @Size(max = 30, message = "{appliance.name.max}")
+    private String name;
+
+    @NotNull(message = "{appliance.manufacturer.id.required}")
+    @Min(1)
+    private Long manufacturerId; // select
+
+    @NotNull(message = "{appliance.category.required}")
+    private Category category; // select
+
+    @Size(max = 30, message = "{appliance.model.max}")
+    private String model;
+
+    @NotNull(message = "{appliance.power.type.required}")
+    private PowerType powerType; // select
+
+    @Size(max = 100, message = "{appliance.characteristic.max}")
+    private String characteristic;
+
+    @Size(max = 300, message = "{appliance.description.max}")
+    private String description;
+
+    @PositiveOrZero(message = "{appliance.power.nonNegative}")
+    private Integer power;
+
+    @NotNull(message = "{appliance.price.required}")
+    @Positive(message = "{appliance.price.positive}")
+    @Digits(integer = 9, fraction = 2, message = "{appliance.price.digits}")
+    private BigDecimal price;
+
+}

--- a/src/main/java/io/github/serhiiklym/appliance_store/controller/dto/ManufacturerForm.java
+++ b/src/main/java/io/github/serhiiklym/appliance_store/controller/dto/ManufacturerForm.java
@@ -8,8 +8,6 @@ import lombok.NoArgsConstructor;
 /**
  * Minimal form object for create/update Manufacturer.
  */
-
-//TODO add messages to props
 @Data
 @NoArgsConstructor
 public class ManufacturerForm {

--- a/src/main/java/io/github/serhiiklym/appliance_store/error/DuplicateApplianceNameException.java
+++ b/src/main/java/io/github/serhiiklym/appliance_store/error/DuplicateApplianceNameException.java
@@ -1,0 +1,7 @@
+package io.github.serhiiklym.appliance_store.error;
+
+public class DuplicateApplianceNameException extends RuntimeException {
+    public DuplicateApplianceNameException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/io/github/serhiiklym/appliance_store/model/Appliance.java
+++ b/src/main/java/io/github/serhiiklym/appliance_store/model/Appliance.java
@@ -40,7 +40,6 @@ public class Appliance {
     private Category category;
 
     @Column(name = "MODEL")
-    @NotBlank
     private String model;
 
     @Column(name = "POWER_TYPE")

--- a/src/main/java/io/github/serhiiklym/appliance_store/model/Manufacturer.java
+++ b/src/main/java/io/github/serhiiklym/appliance_store/model/Manufacturer.java
@@ -14,7 +14,7 @@ public class Manufacturer {
     @Id
     @Column(name = "MANUFACTURER_ID", nullable = false)
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Getter
+    @Getter @Setter
     private Long id;
 
     @Column(name = "NAME", nullable = false, length = 30, unique = true)

--- a/src/main/java/io/github/serhiiklym/appliance_store/repository/ApplianceRepository.java
+++ b/src/main/java/io/github/serhiiklym/appliance_store/repository/ApplianceRepository.java
@@ -4,4 +4,5 @@ import io.github.serhiiklym.appliance_store.model.Appliance;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ApplianceRepository extends JpaRepository<Appliance, Long> {
+    boolean existsByManufacturerIdAndNameIgnoreCase(Long manufacturerId, String name);
 }

--- a/src/main/java/io/github/serhiiklym/appliance_store/repository/ApplianceRepository.java
+++ b/src/main/java/io/github/serhiiklym/appliance_store/repository/ApplianceRepository.java
@@ -1,4 +1,7 @@
 package io.github.serhiiklym.appliance_store.repository;
 
-public interface ApplianceRepository {
+import io.github.serhiiklym.appliance_store.model.Appliance;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ApplianceRepository extends JpaRepository<Appliance, Long> {
 }

--- a/src/main/java/io/github/serhiiklym/appliance_store/repository/util/RepositoryUtilities.java
+++ b/src/main/java/io/github/serhiiklym/appliance_store/repository/util/RepositoryUtilities.java
@@ -1,0 +1,11 @@
+package io.github.serhiiklym.appliance_store.repository.util;
+
+import java.util.Objects;
+
+public class RepositoryUtilities {
+
+    public static String trimInputString(String input) {
+        return Objects.requireNonNull(input, "input must not be null").trim();
+    }
+
+}

--- a/src/main/java/io/github/serhiiklym/appliance_store/service/ApplianceService.java
+++ b/src/main/java/io/github/serhiiklym/appliance_store/service/ApplianceService.java
@@ -1,4 +1,18 @@
 package io.github.serhiiklym.appliance_store.service;
 
+import io.github.serhiiklym.appliance_store.model.Appliance;
+
+import java.util.List;
+
 public interface ApplianceService {
+
+    List<Appliance> list();
+
+    Appliance getByIdOrThrow(Long id);
+
+    Appliance create(String name);
+
+    Appliance update(Long id, String name);
+
+    void deleteAppliance(Long id);
 }

--- a/src/main/java/io/github/serhiiklym/appliance_store/service/ApplianceService.java
+++ b/src/main/java/io/github/serhiiklym/appliance_store/service/ApplianceService.java
@@ -2,6 +2,7 @@ package io.github.serhiiklym.appliance_store.service;
 
 import io.github.serhiiklym.appliance_store.model.Appliance;
 import io.github.serhiiklym.appliance_store.model.Category;
+import io.github.serhiiklym.appliance_store.model.Manufacturer;
 import io.github.serhiiklym.appliance_store.model.PowerType;
 
 import java.math.BigDecimal;
@@ -13,7 +14,7 @@ public interface ApplianceService {
 
     Appliance getByIdOrThrow(Long id);
 
-    Appliance create(String name, Category cat, String model, Long manufacturerId, PowerType powerType,
+    Appliance create(String name, Category cat, String model, Manufacturer manufacturer, PowerType powerType,
                      String props, String descr, Integer power, BigDecimal price);
 
     Appliance update(Long id, String name, Category cat, String model, Long manufacturerId, PowerType powerType,

--- a/src/main/java/io/github/serhiiklym/appliance_store/service/ApplianceService.java
+++ b/src/main/java/io/github/serhiiklym/appliance_store/service/ApplianceService.java
@@ -17,7 +17,7 @@ public interface ApplianceService {
     Appliance create(String name, Category cat, String model, Manufacturer manufacturer, PowerType powerType,
                      String props, String descr, Integer power, BigDecimal price);
 
-    Appliance update(String model, String props, String descr, BigDecimal price);
+    Appliance update(Long id, String model, String props, String descr, BigDecimal price);
 
     void deleteAppliance(Long id);
 }

--- a/src/main/java/io/github/serhiiklym/appliance_store/service/ApplianceService.java
+++ b/src/main/java/io/github/serhiiklym/appliance_store/service/ApplianceService.java
@@ -1,7 +1,10 @@
 package io.github.serhiiklym.appliance_store.service;
 
 import io.github.serhiiklym.appliance_store.model.Appliance;
+import io.github.serhiiklym.appliance_store.model.Category;
+import io.github.serhiiklym.appliance_store.model.PowerType;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 public interface ApplianceService {
@@ -10,9 +13,11 @@ public interface ApplianceService {
 
     Appliance getByIdOrThrow(Long id);
 
-    Appliance create(String name);
+    Appliance create(String name, Category cat, String model, Long manufacturerId, PowerType powerType,
+                     String props, String descr, Integer power, BigDecimal price);
 
-    Appliance update(Long id, String name);
+    Appliance update(Long id, String name, Category cat, String model, Long manufacturerId, PowerType powerType,
+                     String props, String descr, Integer power, BigDecimal price);
 
     void deleteAppliance(Long id);
 }

--- a/src/main/java/io/github/serhiiklym/appliance_store/service/ApplianceService.java
+++ b/src/main/java/io/github/serhiiklym/appliance_store/service/ApplianceService.java
@@ -17,8 +17,7 @@ public interface ApplianceService {
     Appliance create(String name, Category cat, String model, Manufacturer manufacturer, PowerType powerType,
                      String props, String descr, Integer power, BigDecimal price);
 
-    Appliance update(Long id, String name, Category cat, String model, Long manufacturerId, PowerType powerType,
-                     String props, String descr, Integer power, BigDecimal price);
+    Appliance update(String model, String props, String descr, BigDecimal price);
 
     void deleteAppliance(Long id);
 }

--- a/src/main/java/io/github/serhiiklym/appliance_store/service/ApplianceService.java
+++ b/src/main/java/io/github/serhiiklym/appliance_store/service/ApplianceService.java
@@ -1,4 +1,23 @@
 package io.github.serhiiklym.appliance_store.service;
 
+import io.github.serhiiklym.appliance_store.model.Appliance;
+import io.github.serhiiklym.appliance_store.model.Category;
+import io.github.serhiiklym.appliance_store.model.PowerType;
+
+import java.math.BigDecimal;
+import java.util.List;
+
 public interface ApplianceService {
+
+    List<Appliance> list();
+
+    Appliance getByIdOrThrow(Long id);
+
+    Appliance create(String name, Category cat, String model, Long manufacturerId, PowerType powerType,
+                     String props, String descr, Integer power, BigDecimal price);
+
+    Appliance update(Long id, String name, Category cat, String model, Long manufacturerId, PowerType powerType,
+                     String props, String descr, Integer power, BigDecimal price);
+
+    void deleteAppliance(Long id);
 }

--- a/src/main/java/io/github/serhiiklym/appliance_store/service/impl/ApplianceServiceImpl.java
+++ b/src/main/java/io/github/serhiiklym/appliance_store/service/impl/ApplianceServiceImpl.java
@@ -1,6 +1,7 @@
 package io.github.serhiiklym.appliance_store.service.impl;
 
 import io.github.serhiiklym.appliance_store.error.DuplicateApplianceNameException;
+import io.github.serhiiklym.appliance_store.error.DuplicateManufacturerNameException;
 import io.github.serhiiklym.appliance_store.error.NotFoundException;
 import io.github.serhiiklym.appliance_store.model.Appliance;
 import io.github.serhiiklym.appliance_store.model.Category;
@@ -12,6 +13,7 @@ import io.github.serhiiklym.appliance_store.service.ApplianceService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -99,12 +101,38 @@ public class ApplianceServiceImpl implements ApplianceService {
     }
 
     @Override
-    public Appliance update(String model, String props, String descr, BigDecimal price) {
-        return null;
+    public Appliance update(Long id, String model, String props, String descr, BigDecimal price) {
+        log.debug("Updating Appliance by ID={}", id);
+        Appliance a = applianceRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Appliance not found with ID: " + id));
+
+        a.setModel(model);
+        a.setCharacteristic(props);
+        a.setDescription(descr);
+        a.setPrice(price);
+
+
+        try {
+            Appliance saved = applianceRepository.saveAndFlush(a);
+            log.info("Updated appliance with id={}, name={}", saved.getId(), saved.getName());
+            return saved;
+        } catch (DataIntegrityViolationException e) {
+            log.warn("Duplicate appliance on update, id={}", id, e);
+            throw new DuplicateApplianceNameException(
+                    String.format(Locale.ROOT, "Appliance with name '%s' already exists", a.getName())
+            );
+        }
     }
 
     @Override
     public void deleteAppliance(Long id) {
-
+        log.info("Attempting to delete Appliance with ID={}", id);
+        try {
+            applianceRepository.deleteById(id);
+            applianceRepository.flush(); // triggers FK violations
+        } catch (EmptyResultDataAccessException e) {
+            log.warn("No Appliance id={} to delete", id, e);
+            throw new NotFoundException("Appliance not found with ID: " + id); // 404
+        }
     }
 }

--- a/src/main/java/io/github/serhiiklym/appliance_store/service/impl/ApplianceServiceImpl.java
+++ b/src/main/java/io/github/serhiiklym/appliance_store/service/impl/ApplianceServiceImpl.java
@@ -1,4 +1,111 @@
 package io.github.serhiiklym.appliance_store.service.impl;
 
-public class ApplianceServiceImpl {
+import io.github.serhiiklym.appliance_store.error.DuplicateApplianceNameException;
+import io.github.serhiiklym.appliance_store.error.NotFoundException;
+import io.github.serhiiklym.appliance_store.model.Appliance;
+import io.github.serhiiklym.appliance_store.model.Category;
+import io.github.serhiiklym.appliance_store.model.Manufacturer;
+import io.github.serhiiklym.appliance_store.model.PowerType;
+import io.github.serhiiklym.appliance_store.repository.ApplianceRepository;
+import io.github.serhiiklym.appliance_store.repository.ManufacturerRepository;
+import io.github.serhiiklym.appliance_store.service.ApplianceService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Locale;
+
+import static io.github.serhiiklym.appliance_store.repository.util.RepositoryUtilities.trimInputString;
+
+@Slf4j
+@Service
+public class ApplianceServiceImpl implements ApplianceService {
+
+    private final ApplianceRepository applianceRepository;
+    //private final ManufacturerRepository manufacturerRepository;
+
+    @Autowired
+    public ApplianceServiceImpl(ApplianceRepository applianceRepository, ManufacturerRepository manufacturerRepository) {
+        this.applianceRepository = applianceRepository;
+        //this.manufacturerRepository = manufacturerRepository;
+        log.debug("Initialized {} with repo={} and repo={}", getClass().getSimpleName(),
+                applianceRepository.getClass().getSimpleName(), manufacturerRepository.getClass().getSimpleName());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Appliance> list() {
+        log.debug("List of appliances");
+        List<Appliance> result = applianceRepository.findAll();
+        log.debug("List Method…: count={}", result.size());
+        return result;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Appliance getByIdOrThrow(Long id) {
+        log.debug("Fetching Appliance ID={}", id);
+        return applianceRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Appliance not found with ID: " + id));
+    }
+
+    @Override
+    @Transactional
+    public Appliance create(String name, Category cat, String model, Manufacturer manufacturer, PowerType powerType,
+                            String props, String descr, Integer power, BigDecimal price) {
+        var trimmedName = trimInputString(name);
+
+        if (applianceRepository.existsByManufacturerIdAndNameIgnoreCase(manufacturer.getId(), trimmedName)) {
+            throw new DuplicateApplianceNameException(
+                    String.format(Locale.ROOT, "Appliance name '%s' already exists", trimmedName)
+            );
+        }
+//        Manufacturer manufacturer = manufacturerRepository.findById(manufacturerId)
+//                .orElseThrow(() -> new NotFoundException("Creating appliance failed: Manufacturer not found with ID: " + manufacturerId));
+
+
+        var trimmedModel = trimInputString(model);
+        var trimmedProps = trimInputString(props);
+        var trimmedDescr = trimInputString(descr);
+
+        log.debug("Creating an Appliance with name={}, category={}, model={}, brand={}, power type={}, props={}," +
+                        " description={}, power={}, price={}", trimmedName, cat, trimmedModel, manufacturer, powerType, trimmedProps,
+                trimmedDescr, power, price);
+        Appliance a = new Appliance();
+        a.setName(trimmedName);
+        a.setCategory(cat);
+        a.setModel(trimmedModel);
+        a.setManufacturer(manufacturer);
+        a.setPowerType(powerType);
+        a.setCharacteristic(trimmedProps);
+        a.setDescription(trimmedDescr);
+        a.setPower(power);
+        a.setPrice(price);
+
+        try {
+            Appliance saved = applianceRepository.saveAndFlush(a);
+            log.info("Created appliance id={}, name={}, brand={}", saved.getId(), saved.getName(), saved.getManufacturer().getName());
+            return saved;
+        } catch (DataIntegrityViolationException e) { // TODO - for now it's way too broad catch, refactor
+            log.warn("DataIntegrityViolationException on create name={}", trimmedName, e);
+            throw new RuntimeException(
+                    String.format(Locale.ROOT, "Appliance creation RuntimeException", e)
+            );
+        }
+    }
+
+    @Override
+    public Appliance update(Long id, String name, Category cat, String model, Long manufacturerId, PowerType powerType,
+                            String props, String descr, Integer power, BigDecimal price) {
+        return null;
+    }
+
+    @Override
+    public void deleteAppliance(Long id) {
+
+    }
 }

--- a/src/main/java/io/github/serhiiklym/appliance_store/service/impl/ApplianceServiceImpl.java
+++ b/src/main/java/io/github/serhiiklym/appliance_store/service/impl/ApplianceServiceImpl.java
@@ -99,8 +99,7 @@ public class ApplianceServiceImpl implements ApplianceService {
     }
 
     @Override
-    public Appliance update(Long id, String name, Category cat, String model, Long manufacturerId, PowerType powerType,
-                            String props, String descr, Integer power, BigDecimal price) {
+    public Appliance update(String model, String props, String descr, BigDecimal price) {
         return null;
     }
 

--- a/src/main/java/io/github/serhiiklym/appliance_store/service/impl/ManufacturerServiceImpl.java
+++ b/src/main/java/io/github/serhiiklym/appliance_store/service/impl/ManufacturerServiceImpl.java
@@ -14,7 +14,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Locale;
-import java.util.Objects;
+
+import static io.github.serhiiklym.appliance_store.repository.util.RepositoryUtilities.trimInputString;
 
 @Slf4j
 @Service
@@ -100,8 +101,4 @@ public class ManufacturerServiceImpl implements ManufacturerService {
         }
     }
 
-    // -- helpers --
-    private static String trimInputString(String input) {
-        return Objects.requireNonNull(input, "name must not be null").trim();
-    }
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -85,5 +85,31 @@ appliance.price.required=Price is required.
 appliance.price.positive=Price must be greater than zero.
 appliance.price.digits=Price must have at most {integer} integer digits and {fraction} fractional digits.
 
+appliance.header.list=Appliances list
+appliance.btn.new=New appliance
+
+object.appliance.id=ID
+object.appliance.name=Name
+object.appliance.category=Category
+object.appliance.model=Model
+object.appliance.manufacturer=Manufacturer
+object.appliance.powerType=Power type
+object.appliance.characteristic=Features
+object.appliance.description=Description
+object.appliance.power=Power (W)
+object.appliance.price=Price
+
+login.title=Sign in
+login.heading=Sign in
+login.error=Invalid username or password.
+login.loggedout=You have been signed out.
+login.username=Username
+login.password=Password
+login.submit=Sign in
+
+nav.backHome=Back to Home
+
+appliance.name.duplicate=An appliance named "{0}" already exists.
+
 
 

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -49,11 +49,12 @@ home.features.data=Comes with sample data so you can explore right away.
 home.features.security=Role-based access for clients and employees.
 
 btn.edit=EDIT
-btn.save=Apply New Name
+btn.save=Apply
 btn.cancel=Cancel Edit
 btn.delete=DELETE
 
 manufacturer.deleted=Manufacturer deleted.
+manufacturer.created=Manufacturer created.
 manufacturer.delete.constraint=Can't delete this brand because there are products linked to it. Remove or reassign them first.
 manufacturer.updated=The Manufacturer was updated.
 manufacturer.notfound=Brand not found.
@@ -88,6 +89,10 @@ appliance.price.digits=Price must have at most {integer} integer digits and {fra
 appliance.header.list=Appliances list
 appliance.btn.new=New appliance
 
+appliance.deleted=Appliance deleted.
+appliance.updated=Appliance updated.
+appliance.created=Appliance created.
+
 object.appliance.id=ID
 object.appliance.name=Name
 object.appliance.category=Category
@@ -111,5 +116,15 @@ nav.backHome=Back to Home
 
 appliance.name.duplicate=An appliance named "{0}" already exists.
 
+app.name=KWiKi MARKET - The appliance Store.
+footer.who.we.are=Who we are
+footer.about=About
+footer.what.we.do=What we do
+footer.we.work.with.manufacturers=We work with manufacturers
+footer.we.sell.appliances=We sell appliances
+footer.contact.us=Contact us
+footer.contacts=Contacts
+footer.rights=All rights reserved.
+footer.build=S.Klimenko
 
 

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -62,4 +62,28 @@ nav.login=Login
 nav.logout=Logout
 nav.hello=Hello
 
+appliance.name.required=Name is required.
+appliance.name.max=Name must be at most {max} characters.
+
+appliance.manufacturer.id.required=Manufacturer is required.
+appliance.manufacturer.id.positive=Manufacturer is invalid.
+
+appliance.category.required=Category is required.
+
+appliance.model.max=Model must be at most {max} characters.
+
+appliance.power.type.required=Power type is required.
+
+appliance.characteristic.max=Characteristics must be at most {max} characters.
+
+appliance.description.max=Description must be at most {max} characters.
+
+appliance.power.nonNegative=Power must be zero or a positive number.
+appliance.power.required=Power is required.
+
+appliance.price.required=Price is required.
+appliance.price.positive=Price must be greater than zero.
+appliance.price.digits=Price must have at most {integer} integer digits and {fraction} fractional digits.
+
+
 

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -85,3 +85,29 @@ appliance.price.required=Price is required.
 appliance.price.positive=Price must be greater than zero.
 appliance.price.digits=Price must have at most {integer} integer digits and {fraction} fractional digits.
 
+appliance.header.list=Appliances list
+appliance.btn.new=New appliance
+
+object.appliance.id=ID
+object.appliance.name=Name
+object.appliance.category=Category
+object.appliance.model=Model
+object.appliance.manufacturer=Manufacturer
+object.appliance.powerType=Power type
+object.appliance.characteristic=Features
+object.appliance.description=Description
+object.appliance.power=Power (W)
+object.appliance.price=Price
+
+login.title=Sign in
+login.heading=Sign in
+login.error=Invalid username or password.
+login.loggedout=You have been signed out.
+login.username=Username
+login.password=Password
+login.submit=Sign in
+
+nav.backHome=Back to Home
+
+appliance.name.duplicate=An appliance named "{0}" already exists.
+

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -62,4 +62,26 @@ nav.login=Login
 nav.logout=Logout
 nav.hello=Hello
 
+appliance.name.required=Name is required.
+appliance.name.max=Name must be at most {max} characters.
+
+appliance.manufacturer.id.required=Manufacturer is required.
+appliance.manufacturer.id.positive=Manufacturer is invalid.
+
+appliance.category.required=Category is required.
+
+appliance.model.max=Model must be at most {max} characters.
+
+appliance.power.type.required=Power type is required.
+
+appliance.characteristic.max=Characteristics must be at most {max} characters.
+
+appliance.description.max=Description must be at most {max} characters.
+
+appliance.power.nonNegative=Power must be zero or a positive number.
+appliance.power.required=Power is required.
+
+appliance.price.required=Price is required.
+appliance.price.positive=Price must be greater than zero.
+appliance.price.digits=Price must have at most {integer} integer digits and {fraction} fractional digits.
 

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -49,11 +49,12 @@ home.features.data=Comes with sample data so you can explore right away.
 home.features.security=Role-based access for clients and employees.
 
 btn.edit=EDIT
-btn.save=Apply New Name
+btn.save=Apply
 btn.cancel=Cancel Edit
 btn.delete=DELETE
 
 manufacturer.deleted=Manufacturer deleted.
+manufacturer.created=Manufacturer created.
 manufacturer.delete.constraint=Can't delete this brand because there are products linked to it. Remove or reassign them first.
 manufacturer.updated=The Manufacturer was updated.
 manufacturer.notfound=Brand not found.
@@ -88,6 +89,10 @@ appliance.price.digits=Price must have at most {integer} integer digits and {fra
 appliance.header.list=Appliances list
 appliance.btn.new=New appliance
 
+appliance.deleted=Appliance deleted.
+appliance.updated=Appliance updated.
+appliance.created=Appliance created.
+
 object.appliance.id=ID
 object.appliance.name=Name
 object.appliance.category=Category
@@ -111,3 +116,13 @@ nav.backHome=Back to Home
 
 appliance.name.duplicate=An appliance named "{0}" already exists.
 
+app.name=KWiKi MARKET - The appliance Store.
+footer.who.we.are=Who we are
+footer.about=About
+footer.what.we.do=What we do
+footer.we.work.with.manufacturers=We work with manufacturers
+footer.we.sell.appliances=We sell appliances
+footer.contact.us=Contact us
+footer.contacts=Contacts
+footer.rights=All rights reserved.
+footer.build=S.Klimenko

--- a/src/main/resources/messages_uk.properties
+++ b/src/main/resources/messages_uk.properties
@@ -85,5 +85,31 @@ appliance.price.required=Ціна є обов’язковою.
 appliance.price.positive=Ціна має бути більшою за нуль.
 appliance.price.digits=Ціна має містити не більше {integer} цифр у цілій частині та {fraction} — у дробовій.
 
+appliance.header.list=Список техніки
+appliance.btn.new=Додати техніку
+
+object.appliance.id=ID
+object.appliance.name=Назва
+object.appliance.category=Категорія
+object.appliance.model=Модель
+object.appliance.manufacturer=Виробник
+object.appliance.powerType=Тип живлення
+object.appliance.characteristic=Характеристики
+object.appliance.description=Опис
+object.appliance.power=Потужність (Вт)
+object.appliance.price=Ціна
+
+login.title=Вхід
+login.heading=Вхід
+login.error=Невірне ім’я користувача або пароль.
+login.loggedout=Ви вийшли з облікового запису.
+login.username=Ім’я користувача
+login.password=Пароль
+login.submit=Увійти
+
+nav.backHome=Повернутися на головну
+
+appliance.name.duplicate=Техніка з назвою «{0}» уже існує.
+
 
 

--- a/src/main/resources/messages_uk.properties
+++ b/src/main/resources/messages_uk.properties
@@ -62,5 +62,28 @@ nav.login=Увійти
 nav.logout=Вийти
 nav.hello=Вітаємо
 
+appliance.name.required=Назва є обов’язковою.
+appliance.name.max=Довжина назви має бути не більшою за {max} символів.
+
+appliance.manufacturer.id.required=Виробник є обов’язковим.
+appliance.manufacturer.id.positive=Виробник вказано некоректно.
+
+appliance.category.required=Категорія є обов’язковою.
+
+appliance.model.max=Довжина моделі має бути не більшою за {max} символів.
+
+appliance.power.type.required=Тип живлення є обов’язковим.
+
+appliance.characteristic.max=Довжина поля «Характеристики» має бути не більшою за {max} символів.
+
+appliance.description.max=Довжина опису має бути не більшою за {max} символів.
+
+appliance.power.nonNegative=Потужність має бути нульовою або додатною.
+appliance.power.required=Потужність є обов’язковою.
+
+appliance.price.required=Ціна є обов’язковою.
+appliance.price.positive=Ціна має бути більшою за нуль.
+appliance.price.digits=Ціна має містити не більше {integer} цифр у цілій частині та {fraction} — у дробовій.
+
 
 

--- a/src/main/resources/messages_uk.properties
+++ b/src/main/resources/messages_uk.properties
@@ -49,11 +49,12 @@ home.features.data=Тестові дані для швидкого старту.
 home.features.security=Розмежування доступу для клієнтів і співробітників.
 
 btn.edit=РЕДАГУВАТИ
-btn.save=Застосувати Нове Ім'я
+btn.save=Застосувати
 btn.cancel=Скасувати Редагування
 btn.delete=ПОЗБУТИСЯ
 
 manufacturer.deleted=Виробника видалено.
+manufacturer.created=Виробника створено.
 manufacturer.delete.constraint=Неможливо видалити цей бренд, бо до нього прив’язані товари. Спершу видаліть або перев’яжіть їх.
 manufacturer.updated=Бренд змінено.
 manufacturer.notfound=Бренд не знайдено.
@@ -88,6 +89,10 @@ appliance.price.digits=Ціна має містити не більше {integer
 appliance.header.list=Список техніки
 appliance.btn.new=Додати техніку
 
+appliance.deleted=Пристрій видалено.
+appliance.updated=Пристрій змінено.
+appliance.created=Пристрій створено.
+
 object.appliance.id=ID
 object.appliance.name=Назва
 object.appliance.category=Категорія
@@ -111,5 +116,14 @@ nav.backHome=Повернутися на головну
 
 appliance.name.duplicate=Техніка з назвою «{0}» уже існує.
 
-
+app.name=KWiKi MARKET - магазин побутової техніки
+footer.who.we.are=Хто ми
+footer.about=Про нас
+footer.what.we.do=Чим ми займаємось
+footer.we.work.with.manufacturers=Працюємо з виробниками
+footer.we.sell.appliances=Продаємо техніку
+footer.contact.us=Звʼяжіться з нами
+footer.contacts=Контакти
+footer.rights=Всі права захищені.
+footer.build=S.Klimenko
 

--- a/src/main/resources/static/css/main.css
+++ b/src/main/resources/static/css/main.css
@@ -37,3 +37,37 @@
 
 td a { text-decoration: none; }
 td a:hover, td a:focus { text-decoration: underline; }
+
+:root{
+  --brand-primary:#0d6efd;        /* Bootstrap primary */
+  --card-bg: rgba(255,255,255,.85);
+  --ring:#9ec5fe;
+}
+
+/* Full-screen soft gradient */
+.login-bg{
+  background: radial-gradient(1200px 600px at 10% -10%, #e7f1ff 0, transparent 60%),
+              radial-gradient(1200px 700px at 110% 110%, #eaf7ef 0, transparent 60%),
+              linear-gradient(180deg, #f8f9fa 0%, #eef1f6 100%);
+}
+
+/* Glassy card */
+.glass{
+  background: var(--card-bg);
+  backdrop-filter: blur(8px);
+}
+
+/* Inputs: subtle focus ring */
+.form-control:focus{
+  box-shadow: 0 0 0 .25rem var(--ring);
+  border-color: var(--brand-primary);
+}
+
+/* Button shape tweak */
+.btn{
+  border-radius: 0.75rem;
+}
+.card{
+  border-radius: 1rem;
+}
+

--- a/src/main/resources/templates/appliance/appliances.html
+++ b/src/main/resources/templates/appliance/appliances.html
@@ -1,53 +1,89 @@
 <!DOCTYPE html>
 <html lang="${#locale}" xmlns:th="http://www.thymeleaf.org">
 <head>
-    <meta charset="UTF-8">
-    <!-- Latest compiled and minified CSS -->
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <title th:text="#{appliance.header.list}">Appliances</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
-
-    <!-- Latest compiled JavaScript -->
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-    <title>Title</title>
+    <style>
+        /* match Manufacturers behavior: underline links on hover */
+        .table a:hover { text-decoration: underline; }
+    </style>
 </head>
 <body>
-<header>
-    <div th:replace="~{menunavy::navy}"></div>
-</header>
-<main>
-    <h1 th:text="#{appliance.header.list}">Appliances list</h1>
-    <table class="table table-hover">
-        <thead>
-        <tr class="table-dark">
-            <th th:text="#{object.appliance.id}"></th>
-            <th th:text="#{object.appliance.name}"></th>
-            <th th:text="#{object.appliance.category}"></th>
-            <th th:text="#{object.appliance.model}"></th>
-            <th th:text="#{object.appliance.manufacturer}"></th>
-            <th th:text="#{object.appliance.powerType}"></th>
-            <th th:text="#{object.appliance.characteristic}"></th>
-            <th th:text="#{object.appliance.description}"></th>
-            <th th:text="#{object.appliance.power}"></th>
-            <th>Price</th>
-        </tr>
-        </thead>
-        <tbody>
-        <tr th:each="appliance: ${appliances}">
-            <td><span class="float-end" th:text="${appliance.id}"/></td>
-            <td th:text="${appliance.name}"/>
-            <td><span class="float-end" th:text="${appliance.category}"/></td>
-            <td th:text="${appliance.model}"/>
-            <td><span class="float-end" th:text="${appliance.manufacturer.getName()}"/></td>
-            <td th:text="${appliance.powerType}"/>
-            <td th:text="${appliance.characteristic}"/>
-            <td th:text="${appliance.description}"/>
-            <td><span class="float-end" th:text="${appliance.power}"/></td>
-            <td><span class="float-end" th:text="${appliance.price}"/></td>
-        </tr>
 
-        </tbody>
-    </table>
-    <a th:href="@{/appliances/add}" class="btn btn-primary" th:text="#{appliance.btn.new}">New appliance</a>
+<!-- Top navigation / language switcher -->
+<div th:replace="~{menunavy :: navy}"></div>
+
+<!-- Flash messages (same pattern as Manufacturers) -->
+<th:block th:if="${flashSuccess}">
+    <div class="alert alert-success alert-dismissible fade show m-0" role="alert">
+        <span th:text="${#messages.msgOrNull(flashSuccess) ?: flashSuccess}">Success.</span>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+</th:block>
+<th:block th:if="${flashError}">
+    <div class="alert alert-danger alert-dismissible fade show m-0" role="alert">
+        <span th:text="${#messages.msgOrNull(flashError) ?: flashError}">Something went wrong.</span>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+</th:block>
+
+<main class="container mt-3">
+    <div class="d-flex align-items-center justify-content-between mb-3">
+        <h1 class="h3 mb-0" th:text="#{appliance.header.list}">Appliances</h1>
+        <a class="btn btn-primary" th:href="@{/appliances/add}" th:text="#{appliance.btn.new}">New appliance</a>
+    </div>
+
+    <div class="table-responsive">
+        <table class="table table-hover align-middle">
+            <thead class="table-light">
+            <tr>
+                <th scope="col" th:text="#{object.appliance.id}">ID</th>
+                <th scope="col" th:text="#{object.appliance.name}">Name</th>
+                <th scope="col" th:text="#{object.appliance.model}">Model</th>
+                <th scope="col" th:text="#{object.appliance.category}">Category</th>
+                <th scope="col" th:text="#{object.appliance.manufacturer}">Brand</th>
+                <th scope="col" th:text="#{object.appliance.powerType}">Power type</th>
+                <th scope="col" th:text="#{object.appliance.characteristic}">Feats</th>
+                <th scope="col" th:text="#{object.appliance.price}">Price</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="appliance : ${appliances}">
+                <td th:text="${appliance.id}">1</td>
+
+                <!-- Click name to edit -->
+                <td>
+                    <a th:href="@{/appliances/{id}/edit(id=${appliance.id})}"
+                       th:text="${appliance.name}"
+                       th:title="#{btn.edit}">Appliance name</a>
+                </td>
+
+                <td th:text="${appliance.model}">Model X</td>
+                <td th:text="${appliance.category}">CATEGORY</td>
+                <td th:text="${appliance.manufacturer?.name}">Brand</td>
+                <td th:text="${appliance.powerType}">ELECTRIC</td>
+                <td th:text="${appliance.characteristic}">Feats</td>
+
+                <!-- Format price with two decimals; adjust formatter if you prefer -->
+                <td th:text="${#numbers.formatDecimal(appliance.price, 1, 'COMMA', 2, 'POINT')}">199.99</td>
+
+            </tr>
+
+            <!-- Empty state -->
+            <tr th:if="${#lists.isEmpty(appliances)}">
+                <td colspan="8" class="text-center text-muted py-4" th:text="#{appliance.list.empty}">
+                    No appliances yet.
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
 </main>
-<div th:replace="~{footer::footer}"></div>
+
+<div th:replace="~{footer :: footer}"></div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/src/main/resources/templates/appliance/appliances.html
+++ b/src/main/resources/templates/appliance/appliances.html
@@ -10,7 +10,7 @@
         .table a:hover { text-decoration: underline; }
     </style>
 </head>
-<body>
+<body class="d-flex flex-column min-vh-100">
 
 <!-- Top navigation / language switcher -->
 <div th:replace="~{menunavy :: navy}"></div>
@@ -29,7 +29,7 @@
     </div>
 </th:block>
 
-<main class="container mt-3">
+<main class="flex-grow-1">
     <div class="d-flex align-items-center justify-content-between mb-3">
         <h1 class="h3 mb-0" th:text="#{appliance.header.list}">Appliances</h1>
         <a class="btn btn-primary" th:href="@{/appliances/add}" th:text="#{appliance.btn.new}">New appliance</a>

--- a/src/main/resources/templates/appliance/appliances.html
+++ b/src/main/resources/templates/appliance/appliances.html
@@ -46,7 +46,7 @@
 
         </tbody>
     </table>
-    <a th:href="@{appliances/add}" class="btn btn-primary" th:text="#{appliance.btn.new}">New appliance</a>
+    <a th:href="@{/appliances/add}" class="btn btn-primary" th:text="#{appliance.btn.new}">New appliance</a>
 </main>
 <div th:replace="~{footer::footer}"></div>
 </body>

--- a/src/main/resources/templates/appliance/editAppliance.html
+++ b/src/main/resources/templates/appliance/editAppliance.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="${#locale}" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <title th:text="#{appliance.header.edit}">Edit Appliance</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+
+<div th:replace="~{menunavy :: navy}"></div>
+
+<!-- Global alerts -->
+<div th:if="${flashSuccess} and ${param.noflash} == null"
+     class="alert alert-success alert-dismissible fade show" role="alert">
+    <span th:text="${#messages.msgOrNull(flashSuccess) ?: flashSuccess}">Saved.</span>
+    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+</div>
+<div th:if="${flashError} and ${param.noflash} == null"
+     class="alert alert-danger alert-dismissible fade show" role="alert">
+    <span th:text="${#messages.msgOrNull(flashError) ?: flashError}">Error.</span>
+    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+</div>
+
+<main class="container mt-3">
+
+    <h1 class="mb-3" th:text="#{appliance.header.edit}">Edit Appliance</h1>
+
+    <!-- Read-only, always visible (immutable fields) -->
+    <div class="card mb-3">
+        <div class="card-body">
+            <div class="row g-3">
+                <div class="col-md-4">
+                    <label class="form-label" th:text="#{object.appliance.name}">Name</label>
+                    <div class="form-control-plaintext" th:text="${appliance.name}">—</div>
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label" th:text="#{object.appliance.category}">Category</label>
+                    <div class="form-control-plaintext" th:text="${appliance.category}">—</div>
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label" th:text="#{object.appliance.manufacturer}">Brand</label>
+                    <div class="form-control-plaintext" th:text="${appliance.manufacturer.name}">—</div>
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label" th:text="#{object.appliance.powerType}">Power type</label>
+                    <div class="form-control-plaintext" th:text="${appliance.powerType}">—</div>
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label" th:text="#{object.appliance.power}">Power (W)</label>
+                    <div class="form-control-plaintext" th:text="${appliance.power}">—</div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Editable fields -->
+    <form th:action="@{/appliances/{id}(id=${id})}" th:object="${form}" method="post" class="row g-3">
+
+        <div class="col-md-6">
+            <label for="model" class="form-label" th:text="#{object.appliance.model}">Model</label>
+            <input id="model" type="text" th:field="*{model}" class="form-control"/>
+            <div class="invalid-feedback d-block" th:if="${#fields.hasErrors('model')}" th:errors="*{model}">Model error</div>
+        </div>
+
+        <div class="col-md-12">
+            <label for="characteristic" class="form-label" th:text="#{object.appliance.characteristic}">characteristic</label>
+            <textarea id="characteristic" rows="4" th:field="*{characteristic}" class="form-control"></textarea>
+            <div class="invalid-feedback d-block" th:if="${#fields.hasErrors('characteristic')}" th:errors="*{characteristic}">Props error</div>
+        </div>
+
+        <div class="col-md-12">
+            <label for="description" class="form-label" th:text="#{object.appliance.description}">Description</label>
+            <textarea id="description" rows="5" th:field="*{description}" class="form-control"></textarea>
+            <div class="invalid-feedback d-block" th:if="${#fields.hasErrors('description')}" th:errors="*{description}">Description error</div>
+        </div>
+
+        <div class="col-md-4">
+            <label for="price" class="form-label" th:text="#{object.appliance.price}">Price</label>
+            <input id="price" type="number" step="0.01" min="0" th:field="*{price}" class="form-control"/>
+            <div class="invalid-feedback d-block" th:if="${#fields.hasErrors('price')}" th:errors="*{price}">Price error</div>
+        </div>
+
+        <!-- Buttons -->
+        <div class="col-12 d-flex gap-2">
+            <button type="submit"
+                    class="btn btn-primary"
+                    th:text="#{btn.save}">Save</button>
+
+            <a th:href="@{/appliances(noflash=true)}"
+                    class="btn btn-outline-secondary"
+                    th:text="#{btn.cancel}">Cancel</a>
+
+            <button type="submit"
+                    class="btn btn-outline-danger ms-auto"
+                    formmethod="post"
+                    th:formaction="@{/appliances/{id}/delete(id=${id})}"
+                    th:text="#{btn.delete}">
+                Delete
+            </button>
+        </div>
+
+        <!-- CSRF -->
+        <input type="hidden" th:if="${_csrf != null}" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+    </form>
+</main>
+
+<div th:replace="~{footer :: footer}"></div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/src/main/resources/templates/appliance/editAppliance.html
+++ b/src/main/resources/templates/appliance/editAppliance.html
@@ -22,7 +22,7 @@
     <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
 </div>
 
-<main class="container mt-3">
+<main class="flex-grow-1">
 
     <h1 class="mb-3" th:text="#{appliance.header.edit}">Edit Appliance</h1>
 

--- a/src/main/resources/templates/appliance/newAppliance.html
+++ b/src/main/resources/templates/appliance/newAppliance.html
@@ -12,16 +12,16 @@
 <body>
 <div th:replace="~{menunavy::navy}"></div>
 <h1 th:text="#{appliance.btn.new}"></h1>
-<form action="#" th:action="@{add-appliance}" th:object="${appliance}" method="post">
+<form action="#" th:action="@{/appliances}" th:object="${form}" method="post">
     <p>
-    <p th:if="${#fields.hasErrors('name')}" class="text-danger">Invalid name</p>
+    <p th:if="${#fields.hasErrors('name')}" th:errors="*{name}" class="text-danger"></p>
     <span th:text="#{object.appliance.name}">
         </span> <input type="text" th:field="*{name}"/>
     </p>
 
 
     <p>
-    <p th:if="${#fields.hasErrors('category')}" class="text-danger">Invalid category</p>
+    <p th:if="${#fields.hasErrors('category')}" th:errors="*{category}" class="text-danger"></p>
     <span th:text="#{object.appliance.category}"></span>
 
     <select th:field="*{category}">
@@ -29,13 +29,13 @@
     </select>
     </p>
     <p>
-    <p th:if="${#fields.hasErrors('model')}" class="text-danger">Invalid model</p>
+    <p th:if="${#fields.hasErrors('model')}" th:errors="*{model}" class="text-danger"></p>
     <span th:text="#{object.appliance.model}"></span>
     <input type="text" th:field="*{model}"/>
     </p>
 
     <p>
-    <p th:if="${#fields.hasErrors('manufacturer')}" class="text-danger">Invalid manufacturer</p>
+    <p th:if="${#fields.hasErrors('manufacturer')}" th:errors="*{manufacturer}" class="text-danger"></p>
     <span th:text="#{object.appliance.manufacturer}"></span>
 
     <select th:field="*{manufacturer}">
@@ -44,7 +44,7 @@
     </select>
     </p>
     <p>
-    <p th:if="${#fields.hasErrors('powerType')}" class="text-danger">Invalid power type</p>
+    <p th:if="${#fields.hasErrors('powerType')}" th:errors="*{powerType}" class="text-danger"></p>
     <span th:text="#{object.appliance.powerType}"></span>
 
     <select th:field="*{powerType}">
@@ -53,24 +53,24 @@
     </p>
 
     <p>
-    <p th:if="${#fields.hasErrors('characteristic')}" class="text-danger">Invalid characteristic</p>
+    <p th:if="${#fields.hasErrors('characteristic')}" th:errors="*{characteristic}" class="text-danger"></p>
     <span th:text="#{object.appliance.characteristic}"></span>
     <input type="text" th:field="*{characteristic}"/>
     </p>
 
     <p>
-    <p th:if="${#fields.hasErrors('description')}" class="text-danger">Invalid description</p>
+    <p th:if="${#fields.hasErrors('description')}" th:errors="*{description}" class="text-danger"></p>
     <span th:text="#{object.appliance.description}"></span>
     <input type="text" th:field="*{description}"/>
     </p>
 
     <p>
-    <p th:if="${#fields.hasErrors('power')}" class="text-danger">Invalid power</p>
+    <p th:if="${#fields.hasErrors('power')}" th:errors="*{power}" class="text-danger"></p>
     <span th:text="#{object.appliance.power}"></span>
     <input type="text" th:field="*{power}"/>
     </p>
     <p>
-    <p th:if="${#fields.hasErrors('price')}" class="text-danger">Invalid price</p>
+    <p th:if="${#fields.hasErrors('price')}" th:errors="*{price}" class="text-danger"></p>
     <span th:text="#{object.appliance.price}"></span>
     <input type="text" th:field="*{price}"/>
     </p>

--- a/src/main/resources/templates/footer.html
+++ b/src/main/resources/templates/footer.html
@@ -1,11 +1,55 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html lang="en"
+      xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="https://www.thymeleaf.org/extras/spring-security">
 <body>
+<!-- Footer Fragment -->
+<footer th:fragment="footer"
+        class="mt-auto border-top bg-light">
+    <div class="container py-4">
+        <div class="row g-3">
+            <!-- About -->
+            <div class="col-12 col-md-4">
+                <h6 class="text-uppercase mb-3" th:text="#{footer.who.we.are}">About</h6>
+                <a th:href="@{/}" class="link-secondary" th:text="#{footer.about}">Contact</a>
+            </div>
 
-    <footer th:fragment="footer" class="footer fixed-bottom text-center">
-        <div>
-            <span class="text-center">© 2025 Serhii Klymenko Spring Web App project</span>
+            <!-- Our business -->
+            <div class="col-12 col-md-4">
+                <h6 class="text-uppercase mb-3" th:text="#{footer.what.we.do}">Explore</h6>
+                <nav aria-label="Footer" class="d-flex flex-column gap-2">
+                    <a th:href="@{/manufacturers}" class="link-secondary" th:text="#{footer.we.work.with.manufacturers}">Manufacturers</a>
+                    <a th:href="@{/appliances}" class="link-secondary" th:text="#{footer.we.sell.appliances}">Appliances</a>
+                </nav>
+            </div>
+
+            <!-- Contacts -->
+            <div class="col-12 col-md-4">
+                <h6 class="text-uppercase mb-3" th:text="#{footer.contact.us}">Help &amp; Legal</h6>
+                <nav class="d-flex flex-column gap-2">
+<!--                    // TODO contacts.html -->
+                    <a th:href="@{/contacts}" class="link-secondary" th:text="#{footer.contacts}">Contacts</a>
+                </nav>
+
+            </div>
         </div>
-    </footer>
+
+        <hr class="my-4">
+
+        <div class="d-flex flex-column flex-md-row justify-content-between align-items-start align-items-md-center small text-secondary">
+            <div>
+                <!-- © YEAR AppName. All rights reserved. -->
+                <span>&copy; <span th:text="${#temporals.createNow().year}">2069</span></span>
+                <span th:text="#{app.name}">Appliance Store</span>.
+                <span th:text="#{footer.rights}">All rights reserved.</span>
+            </div>
+            <div class="mt-2 mt-md-0">
+                <span class="me-2" th:text="#{footer.build}">Build</span>
+                <code th:text="${@environment?.getProperty('app.version', 'v0.1')}"
+                      class="text-muted">v0.1</code>
+            </div>
+        </div>
+    </div>
+</footer>
 </body>
 </html>

--- a/src/main/resources/templates/login/login.html
+++ b/src/main/resources/templates/login/login.html
@@ -3,38 +3,69 @@
 <head>
   <meta charset="UTF-8" />
   <title th:text="#{login.title}">Sign in</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link rel="stylesheet" th:href="@{/css/main.css}" />
-  <!-- If you use Bootstrap, include it here -->
-</head>
-<body>
-<main class="container" style="max-width: 420px; margin-top: 3rem;">
-  <h1 class="mb-3" th:text="#{login.heading}">Sign in</h1>
+  </head>
+<body class="login-bg d-flex align-items-center min-vh-100">
+<main class="container">
+  <div class="row justify-content-center">
+    <div class="col-12 col-sm-10 col-md-7 col-lg-5">
+      <section class="card shadow-lg rounded-4 border-0 glass">
+        <div class="card-body p-4 p-md-5">
+          <!-- Brand / title -->
+          <h1 class="h3 fw-semibold mb-4 text-center" th:text="#{login.heading}">Sign in</h1>
 
-  <!-- Login errors and logout notice -->
-  <div th:if="${param.error}"
-       th:replace="~{fragments/alerts :: alert('danger', #{login.error})}"></div>
+          <!-- Alerts -->
+          <div th:if="${param.error}" class="alert alert-danger" role="alert"
+               th:text="#{login.error}">Invalid username or password.</div>
+          <div th:if="${param.logout}" class="alert alert-success" role="alert"
+               th:text="#{login.loggedout}">You have been signed out.</div>
 
-  <div th:if="${param.logout}"
-       th:replace="~{fragments/alerts :: alert('success', #{login.loggedout})}"></div>
+          <form th:action="@{/login}" method="post" novalidate>
+            <div class="mb-3">
+              <label for="username" class="form-label" th:text="#{login.username}">Username</label>
+              <input id="username" name="username" type="text" class="form-control form-control-lg"
+                     required autofocus autocomplete="username" />
+            </div>
 
-  <form th:action="@{/login}" method="post" class="card p-3 shadow-sm">
-    <label for="username" class="form-label" th:text="#{login.username}">Username</label>
-    <input id="username" name="username" type="text" class="form-control" required autofocus />
+            <div class="mb-2">
+              <label for="password" class="form-label d-flex justify-content-between">
+                <span th:text="#{login.password}">Password</span>
+                <a th:href="@{/}" class="small text-decoration-none" th:text="#{nav.backHome}">Back to Home</a>
+              </label>
+              <div class="input-group input-group-lg">
+                <input id="password" name="password" type="password" class="form-control"
+                       required autocomplete="current-password" />
+                <button type="button" class="btn btn-outline-secondary" id="togglePwd" aria-label="Show password">
+                  <span class="visually-hidden">Toggle</span>👁
+                </button>
+              </div>
+            </div>
 
-    <label for="password" class="form-label mt-3" th:text="#{login.password}">Password</label>
-    <input id="password" name="password" type="password" class="form-control" required />
+            <!-- CSRF -->
+            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
 
-    <!-- CSRF token -->
-    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
-
-    <button class="btn btn-primary mt-3 w-100" type="submit" th:text="#{login.submit}">
-      Sign in
-    </button>
-  </form>
-
-  <p class="mt-3">
-    <a th:href="@{/}" th:text="#{nav.backHome}">Back to home</a>
-  </p>
+            <button class="btn btn-primary btn-lg w-100 mt-3" type="submit" th:text="#{login.submit}">
+              Sign in
+            </button>
+          </form>
+        </div>
+      </section>
+      <p class="text-center mt-3 small text-muted">© 2025 Serhii Klymenko</p>
+    </div>
+  </div>
 </main>
+
+<script>
+  // Simple show/hide password toggle
+  const toggle = document.getElementById('togglePwd');
+  const pwd = document.getElementById('password');
+  if (toggle && pwd) {
+    toggle.addEventListener('click', () => {
+      pwd.type = pwd.type === 'password' ? 'text' : 'password';
+    });
+  }
+</script>
 </body>
+
 </html>

--- a/src/main/resources/templates/manufacturer/editManufacturer.html
+++ b/src/main/resources/templates/manufacturer/editManufacturer.html
@@ -49,7 +49,10 @@
     <!-- Buttons -->
     <div class="col-12">
       <button type="submit" class="btn btn-primary" th:text="#{btn.save}">Save</button>
-      <a th:href="@{/manufacturers(noflash=true)}" class="btn btn-outline-secondary" th:text="#{btn.cancel}">Cancel</a>
+
+      <a th:href="@{/manufacturers(noflash=true)}"
+            class="btn btn-outline-secondary"
+            th:text="#{btn.cancel}">Cancel</a>
 
       <button type="submit"
               class="btn btn-outline-danger ms-auto"

--- a/src/main/resources/templates/manufacturer/editManufacturer.html
+++ b/src/main/resources/templates/manufacturer/editManufacturer.html
@@ -29,7 +29,7 @@
 </div>
 
 
-<main class="container mt-3">
+<main class="flex-grow-1">
   <h1 class="mb-3" th:text="#{manufacturer.header.edit}">Edit Manufacturer</h1>
 
   <!-- Edit form -->

--- a/src/test/java/io/github/serhiiklym/appliance_store/controller/ApplianceControllerWebMvcTest.java
+++ b/src/test/java/io/github/serhiiklym/appliance_store/controller/ApplianceControllerWebMvcTest.java
@@ -1,0 +1,158 @@
+package io.github.serhiiklym.appliance_store.controller;
+
+import io.github.serhiiklym.appliance_store.error.DuplicateApplianceNameException;
+import io.github.serhiiklym.appliance_store.error.NotFoundException;
+import io.github.serhiiklym.appliance_store.model.Appliance;
+import io.github.serhiiklym.appliance_store.model.Manufacturer;
+import io.github.serhiiklym.appliance_store.service.ApplianceService;
+import io.github.serhiiklym.appliance_store.service.ManufacturerService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * Assumes:
+ *  - @Controller class ApplianceController mapped at "/appliances"
+ *  - list(): model.addAttribute("appliances", service.list()); returns "appliance/appliances"
+ *  - GET "/new" -> "appliance/newAppliance"
+ *  - POST "/" (create) with @ModelAttribute("form") -> redirect on success; on errors stays on "appliance/newAppliance"
+ *  - GET "/{id}/edit" -> "appliance/editAppliance"
+ *  - POST "/{id}" (update) -> redirect on success; stays on edit on errors
+ *  - POST "/{id}/delete" (delete) -> redirect with flash
+ */
+@WebMvcTest(controllers = ApplianceController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class ApplianceControllerWebMvcTest {
+
+    @Autowired MockMvc mvc;
+
+    @MockitoBean ApplianceService service;
+    @MockitoBean ManufacturerService manufacturerService;
+
+    @Test
+    @DisplayName("GET /appliances: renders list view with appliances model")
+    void list_rendersView() throws Exception {
+        var a1 = new Appliance(); a1.setId(1L);
+        var a2 = new Appliance(); a2.setId(2L);
+        given(service.list()).willReturn(List.of(a1, a2));
+
+        mvc.perform(get("/appliances"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("appliance/appliances"))
+                .andExpect(model().attributeExists("appliances"))
+                .andExpect(model().attribute("appliances", hasSize(2)));
+    }
+
+    @Test
+    @DisplayName("POST /appliances: valid create -> redirect with success flash")
+    void create_valid_redirects() throws Exception {
+        when(service.create(anyString(), any(), anyString(), any(Manufacturer.class), any(), anyString(),
+                anyString(), anyInt(), any(BigDecimal.class)))
+                .thenReturn(new Appliance());
+
+        mvc.perform(post("/appliances")
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                        // minimal required fields (adjust param names to your form if needed)
+                        .param("name", "Blender")
+                        .param("category", "SMALL") // enum binder; adjust if your values differ
+                        .param("model", "BL-100")
+                        .param("manufacturer.id", "1")
+                        .param("powerType", "ACCUMULATOR")
+                        .param("characteristic", "500W; steel")
+                        .param("description", "Nice one")
+                        .param("power", "5000")
+                        .param("price", "149.99")
+                )
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/appliances"))
+                .andExpect(flash().attributeExists("flashSuccess"));
+    }
+
+    @Test
+    @DisplayName("POST /appliances: invalid form -> stays on page and shows errors")
+    void create_invalid_showsErrors() throws Exception {
+        // Force validation failure by missing required fields (e.g., name, price)
+        mvc.perform(post("/appliances")
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                        .param("name", "")           // @NotBlank
+                        .param("price", "-1")        // @Positive
+                )
+                .andExpect(status().isOk())
+                .andExpect(view().name("appliance/newAppliance"))
+                .andExpect(model().hasErrors());
+    }
+
+    @Test
+    @DisplayName("POST /appliances: duplicate -> stays on page with field error")
+    void create_duplicate_staysWithError() throws Exception {
+        when(service.create(anyString(), any(), anyString(), any(Manufacturer.class), any(), anyString(),
+                anyString(), anyInt(), any(BigDecimal.class)))
+                .thenThrow(new DuplicateApplianceNameException("duplicate"));
+
+        mvc.perform(post("/appliances")
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                        .param("name", "Blender")
+                        .param("model", "BL-100")
+                        .param("manufacturer.id", "1")
+                        .param("price", "149.99")
+                )
+                .andExpect(status().isOk())
+                .andExpect(view().name("appliance/newAppliance"))
+                .andExpect(model().hasErrors());
+    }
+
+    @Test
+    @DisplayName("POST /appliances/{id}: valid update -> redirect with success flash")
+    void update_valid_redirects() throws Exception {
+        mvc.perform(post("/appliances/{id}", 10L)
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                        .param("model", "NEW-MOD")
+                        .param("characteristic", "NEW-PROPS")
+                        .param("description", "NEW-DESC")
+                        .param("price", "2.50")
+                )
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/appliances"))
+                .andExpect(flash().attributeExists("flashSuccess"));
+
+        verify(service).update(eq(10L), eq("NEW-MOD"), eq("NEW-PROPS"), eq("NEW-DESC"), eq(new BigDecimal("2.50")));
+    }
+
+    @Test
+    @DisplayName("POST /appliances/{id}/delete: success -> redirect with success flash")
+    void delete_success() throws Exception {
+        mvc.perform(post("/appliances/{id}/delete", 5L))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/appliances"))
+                .andExpect(flash().attributeExists("flashSuccess"));
+
+        verify(service).deleteAppliance(5L);
+    }
+
+    @Test
+    @DisplayName("POST /appliances/{id}/delete: not found -> redirect with error flash")
+    void delete_notFound() throws Exception {
+        doThrow(new NotFoundException("missing")).when(service).deleteAppliance(123L);
+
+        mvc.perform(post("/appliances/{id}/delete", 123L))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/appliances"))
+                .andExpect(flash().attributeExists("flashError"));
+    }
+}

--- a/src/test/java/io/github/serhiiklym/appliance_store/repository/ApplianceRepositoryTest.java
+++ b/src/test/java/io/github/serhiiklym/appliance_store/repository/ApplianceRepositoryTest.java
@@ -1,0 +1,61 @@
+package io.github.serhiiklym.appliance_store.repository;
+
+import io.github.serhiiklym.appliance_store.model.Appliance;
+import io.github.serhiiklym.appliance_store.model.Manufacturer;
+import io.github.serhiiklym.appliance_store.model.Category;
+import io.github.serhiiklym.appliance_store.model.PowerType;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Web MVC slice tests for ApplianceController.
+ * Loads only MVC + the controller via @WebMvcTest; replaces collaborators with @MockitoBean mocks.
+ * Security filters disabled (@AutoConfigureMockMvc(addFilters = false)) to focus on views, model, redirects, and validation.
+ * Does NOT test security rules or persistence.
+ */
+
+@DataJpaTest
+class ApplianceRepositoryTest {
+
+    @Autowired TestEntityManager em;
+    @Autowired ApplianceRepository repo;
+
+    @Test
+    void existsByManufacturerIdAndNameIgnoreCase_behavesAsExpected() {
+        // given a manufacturer
+        Manufacturer m1 = new Manufacturer();
+        m1.setName("BrandA");
+        m1 = em.persistFlushFind(m1);
+
+        Manufacturer m2 = new Manufacturer();
+        m2.setName("BrandB");
+        m2 = em.persistFlushFind(m2);
+
+        // and an appliance under m1 with name 'Blender'
+        Appliance a = new Appliance();
+        a.setName("Blender");
+        // pick the first enum constants to avoid coupling to specific names
+        a.setCategory(Category.values()[0]);
+        a.setModel("BL-100");
+        a.setManufacturer(m1);
+        a.setPowerType(PowerType.values()[0]);
+        a.setCharacteristic("500W; steel");
+        a.setDescription("A nice blender");
+        a.setPower(500);
+        a.setPrice(new BigDecimal("149.99"));
+        em.persist(a);
+        em.flush();
+
+        // when/then
+        assertThat(repo.existsByManufacturerIdAndNameIgnoreCase(m1.getId(), "blender")).isTrue();
+        assertThat(repo.existsByManufacturerIdAndNameIgnoreCase(m1.getId(), "BLENDER")).isTrue(); // case-insensitive
+        assertThat(repo.existsByManufacturerIdAndNameIgnoreCase(m1.getId(), "Mixer")).isFalse(); // different name
+        assertThat(repo.existsByManufacturerIdAndNameIgnoreCase(m2.getId(), "Blender")).isFalse(); // different brand
+    }
+}

--- a/src/test/java/io/github/serhiiklym/appliance_store/service/impl/ApplianceServiceImplTest.java
+++ b/src/test/java/io/github/serhiiklym/appliance_store/service/impl/ApplianceServiceImplTest.java
@@ -1,0 +1,163 @@
+package io.github.serhiiklym.appliance_store.service.impl;
+
+import io.github.serhiiklym.appliance_store.error.DuplicateApplianceNameException;
+import io.github.serhiiklym.appliance_store.error.NotFoundException;
+import io.github.serhiiklym.appliance_store.model.Appliance;
+import io.github.serhiiklym.appliance_store.model.Manufacturer;
+import io.github.serhiiklym.appliance_store.repository.ApplianceRepository;
+import io.github.serhiiklym.appliance_store.repository.ManufacturerRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
+import org.springframework.dao.EmptyResultDataAccessException;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ApplianceServiceImplTest {
+
+    @Mock ApplianceRepository applianceRepository;
+    @Mock ManufacturerRepository manufacturerRepository;
+
+    @InjectMocks ApplianceServiceImpl service; // concrete class under test
+
+    @Test
+    @DisplayName("list(): delegates to repository and returns all")
+    void list_returnsAll() {
+        when(applianceRepository.findAll()).thenReturn(List.of(new Appliance(), new Appliance()));
+        assertThat(service.list()).hasSize(2);
+        verify(applianceRepository, times(1)).findAll();
+        verifyNoMoreInteractions(applianceRepository);
+    }
+
+    @Test
+    @DisplayName("getByIdOrThrow(): returns entity when found")
+    void getByIdOrThrow_found() {
+        Appliance a = new Appliance();
+        a.setId(42L);
+        when(applianceRepository.findById(42L)).thenReturn(Optional.of(a));
+
+        var found = service.getByIdOrThrow(42L);
+
+        assertThat(found).isSameAs(a);
+        verify(applianceRepository).findById(42L);
+    }
+
+    @Test
+    @DisplayName("getByIdOrThrow(): throws NotFound when missing")
+    void getByIdOrThrow_notFound() {
+        when(applianceRepository.findById(99L)).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> service.getByIdOrThrow(99L))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("99");
+    }
+
+    @Test
+    @DisplayName("create(): happy path saves and returns the entity")
+    void create_happyPath() {
+        Manufacturer m = new Manufacturer();
+        m.setId(1L);
+        // duplicate check must be false
+        when(applianceRepository.existsByManufacturerIdAndNameIgnoreCase(eq(1L), eq("Blender"))).thenReturn(false);
+
+        // accept either save() or saveAndFlush() depending on impl; stub both safely
+        Answer<Appliance> saver = inv -> {
+            Appliance saved = inv.getArgument(0, Appliance.class);
+            saved.setId(1L);
+            return saved;
+        };
+
+        when(applianceRepository.saveAndFlush(any(Appliance.class))).thenAnswer(saver);
+
+        var created = service.create(
+                "  Blender  ", /*cat*/ null, "B123", m, /*powerType*/ null,
+                "specs", "desc", 500, new BigDecimal("149.99")
+        );
+
+        assertThat(created.getId()).isEqualTo(1L);
+        assertThat(created.getName()).isEqualTo("Blender"); // trimmed
+        assertThat(created.getManufacturer()).isSameAs(m);
+        verify(applianceRepository).existsByManufacturerIdAndNameIgnoreCase(1L, "Blender");
+        // one of these two will be called by your impl:
+        verify(applianceRepository, atMostOnce()).save(any(Appliance.class));
+        verify(applianceRepository, atMostOnce()).saveAndFlush(any(Appliance.class));
+    }
+
+    @Test
+    @DisplayName("create(): duplicate name under same manufacturer -> DuplicateApplianceNameException")
+    void create_duplicateName() {
+        Manufacturer m = new Manufacturer();
+        m.setId(7L);
+        when(applianceRepository.existsByManufacturerIdAndNameIgnoreCase(7L, "Blender")).thenReturn(true);
+
+        assertThatThrownBy(() ->
+                service.create("Blender", null, "B123", m, null, "specs", "desc", 500, new BigDecimal("149.99"))
+        ).isInstanceOf(DuplicateApplianceNameException.class);
+
+        verify(applianceRepository).existsByManufacturerIdAndNameIgnoreCase(7L, "Blender");
+        verifyNoMoreInteractions(applianceRepository);
+    }
+
+    @Test
+    @DisplayName("update(): updates mutable fields and saves")
+    void update_happyPath() {
+        Appliance existing = new Appliance();
+        existing.setId(10L);
+        existing.setModel("OLD");
+        existing.setCharacteristic("OLD");
+        existing.setDescription("OLD");
+        existing.setPrice(new BigDecimal("1.00"));
+
+        when(applianceRepository.findById(10L)).thenReturn(Optional.of(existing));
+        when(applianceRepository.saveAndFlush(any(Appliance.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        var updated = service.update(10L, "NEW-MOD", "NEW-PROPS", "NEW-DESC", new BigDecimal("2.50"));
+
+        assertThat(updated.getModel()).isEqualTo("NEW-MOD");
+        assertThat(updated.getCharacteristic()).isEqualTo("NEW-PROPS");
+        assertThat(updated.getDescription()).isEqualTo("NEW-DESC");
+        assertThat(updated.getPrice()).isEqualByComparingTo("2.50");
+
+        verify(applianceRepository).findById(10L);
+        verify(applianceRepository).saveAndFlush(existing);
+    }
+
+    @Test
+    @DisplayName("update(): throws NotFound when id missing")
+    void update_notFound() {
+        when(applianceRepository.findById(111L)).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> service.update(111L, "M", "P", "D", new BigDecimal("3.00")))
+                .isInstanceOf(NotFoundException.class);
+        verify(applianceRepository).findById(111L);
+        verify(applianceRepository, never()).saveAndFlush(any());
+    }
+
+    @Test
+    @DisplayName("deleteAppliance(): deletes and flushes")
+    void delete_success() {
+        // no stubbing needed for voids; verify interaction
+        service.deleteAppliance(5L);
+        verify(applianceRepository).deleteById(5L);
+        verify(applianceRepository).flush();
+    }
+
+    @Test
+    @DisplayName("deleteAppliance(): translates EmptyResultDataAccessException to NotFoundException")
+    void delete_notFound() {
+        doThrow(new EmptyResultDataAccessException(1)).when(applianceRepository).deleteById(123L);
+        assertThatThrownBy(() -> service.deleteAppliance(123L))
+                .isInstanceOf(NotFoundException.class);
+        verify(applianceRepository).deleteById(123L);
+        // flush not called when delete fails
+        verify(applianceRepository, never()).flush();
+    }
+}


### PR DESCRIPTION
Introduce the Appliance feature as a vertical slice: domain model, persistence, service layer with validation, MVC endpoints, and Thymeleaf views. Adds pagination/sorting on the list page, localized UI strings, and role-based access.

**Scope / What changed**

**Domain & persistence**
	- Appliance entity with fields (e.g., name, price, category) and ManyToOne Manufacturer.
	- JPA mappings, repository (JpaRepository/PagingAndSortingRepository) for paging & sorting.
**Service layer**
	- CRUD operations with Bean Validation (e.g., name not blank, price > 0).
	- Business rules: prevent duplicates (if applicable).
**Web / MVC**
	- Controller endpoints for list, create, edit, delete.
	- Form/DTO for safe binding + validation errors.
	- Thymeleaf pages: list, new, edit with flash messages and field-level errors.
	- Pagination controls and sortable headers on the list page.
**Security (RBAC)**
	- CLIENT: read-only list/details.
	- EMPLOYEE/ADMIN: create, edit, delete.
**i18n**
	- New message keys for labels, buttons, and validation feedback.
	- Integrated with the existing language switcher.
**Navigation**
	- Menu entry for Appliances.