### PR TITLE
PR: Orders: repositories + service interface (merge duplicates, zero-qty auto-delete)

### DIFF
--- a/src/main/java/io/github/serhiiklym/appliance_store/error/DuplicateOrderIdException.java
+++ b/src/main/java/io/github/serhiiklym/appliance_store/error/DuplicateOrderIdException.java
@@ -1,0 +1,7 @@
+package io.github.serhiiklym.appliance_store.error;
+
+public class DuplicateOrderIdException extends RuntimeException {
+    public DuplicateOrderIdException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/io/github/serhiiklym/appliance_store/error/OrderIsApprovedAndClosedToModificationsException.java
+++ b/src/main/java/io/github/serhiiklym/appliance_store/error/OrderIsApprovedAndClosedToModificationsException.java
@@ -1,0 +1,7 @@
+package io.github.serhiiklym.appliance_store.error;
+
+public class OrderIsApprovedAndClosedToModificationsException extends RuntimeException {
+    public OrderIsApprovedAndClosedToModificationsException(Long orderId) {
+        super("The order is already approved — no further modifications allowed (orderId=" + orderId + ")");
+    }
+}

--- a/src/main/java/io/github/serhiiklym/appliance_store/model/OrderRow.java
+++ b/src/main/java/io/github/serhiiklym/appliance_store/model/OrderRow.java
@@ -38,4 +38,9 @@ public class OrderRow {
     @Positive
     private BigDecimal amount;
 
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "ORDER_ID", nullable = false)
+    private Orders order;
+
+
 }

--- a/src/main/java/io/github/serhiiklym/appliance_store/model/Orders.java
+++ b/src/main/java/io/github/serhiiklym/appliance_store/model/Orders.java
@@ -18,7 +18,7 @@ import java.util.Set;
 @Setter
 public class Orders {
 
-    @OneToMany()
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<OrderRow> orderRowSet = new HashSet<>();
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/io/github/serhiiklym/appliance_store/repository/ApplianceRepository.java
+++ b/src/main/java/io/github/serhiiklym/appliance_store/repository/ApplianceRepository.java
@@ -4,5 +4,7 @@ import io.github.serhiiklym.appliance_store.model.Appliance;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ApplianceRepository extends JpaRepository<Appliance, Long> {
+
     boolean existsByManufacturerIdAndNameIgnoreCase(Long manufacturerId, String name);
+
 }

--- a/src/main/java/io/github/serhiiklym/appliance_store/repository/ClientRepository.java
+++ b/src/main/java/io/github/serhiiklym/appliance_store/repository/ClientRepository.java
@@ -1,4 +1,7 @@
 package io.github.serhiiklym.appliance_store.repository;
 
-public interface ClientRepository {
+import io.github.serhiiklym.appliance_store.model.Client;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ClientRepository extends JpaRepository<Client, Long> {
 }

--- a/src/main/java/io/github/serhiiklym/appliance_store/repository/OrderRowRepository.java
+++ b/src/main/java/io/github/serhiiklym/appliance_store/repository/OrderRowRepository.java
@@ -1,0 +1,19 @@
+package io.github.serhiiklym.appliance_store.repository;
+
+import io.github.serhiiklym.appliance_store.model.OrderRow;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface OrderRowRepository extends JpaRepository<OrderRow, Long> {
+
+    List<OrderRow> findAllByOrder_Id(Long orderId);
+
+    boolean existsByOrder_IdAndAppliance_Id(Long orderId, Long applianceId);
+
+    Optional<OrderRow> findByOrder_IdAndAppliance_Id(Long orderId, Long applianceId);
+
+    long deleteByOrder_IdAndId(Long orderId, Long rowId);
+
+}

--- a/src/main/java/io/github/serhiiklym/appliance_store/repository/OrdersRepository.java
+++ b/src/main/java/io/github/serhiiklym/appliance_store/repository/OrdersRepository.java
@@ -1,4 +1,20 @@
 package io.github.serhiiklym.appliance_store.repository;
 
-public interface OrdersRepository {
+import io.github.serhiiklym.appliance_store.model.Orders;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface OrdersRepository extends JpaRepository<Orders, Long> {
+
+    Page<Orders> findAllByApproved(boolean approved, Pageable pageable);
+
+    Page<Orders>  findAllByClient_Id(Long clientId, Pageable pageable);
+
+    Optional<Orders> findByIdAndClient_Id(Long orderId, Long clientId);
+
+    boolean existsByIdAndClient_Id(Long orderId, Long clientId);
+
 }

--- a/src/main/java/io/github/serhiiklym/appliance_store/service/OrderService.java
+++ b/src/main/java/io/github/serhiiklym/appliance_store/service/OrderService.java
@@ -18,7 +18,7 @@ public interface OrderService {
      * Add a row with the given appliance and quantity.
      * If a row for the same appliance exists in the same order, quantities are merged.
      */
-    Orders addRow (Long orderId, Long applianceId, int qty);
+    Orders addRow (Long orderId, Long applianceId, Long qty);
 
     /**
      * Change quantity of a specific row.

--- a/src/main/java/io/github/serhiiklym/appliance_store/service/OrderService.java
+++ b/src/main/java/io/github/serhiiklym/appliance_store/service/OrderService.java
@@ -1,4 +1,35 @@
 package io.github.serhiiklym.appliance_store.service;
 
+import io.github.serhiiklym.appliance_store.model.Orders;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.math.BigDecimal;
+
 public interface OrderService {
+    Page<Orders> list(Pageable pageable);
+    Page<Orders> listByClient(Long clientId, Pageable pageable);
+    Page<Orders> listByApproved(boolean approved, Pageable pageable);
+    BigDecimal getTotal(Long orderId);
+
+    Orders createOrder (Long clientId);
+    // --  only if not approved
+    /**
+     * Add a row with the given appliance and quantity.
+     * If a row for the same appliance exists in the same order, quantities are merged.
+     */
+    Orders addRow (Long orderId, Long applianceId, int qty);
+
+    /**
+     * Change quantity of a specific row.
+     * If newQty == 0, the row is auto-deleted.
+     */
+    Orders updateRowQuantity (Long orderId, Long rowId, int qty);
+    void removeRow(Long orderId, Long rowId);
+
+    /**
+     * Approve a non-empty draft order and record the approver (employee).
+     * After approval the order becomes immutable.
+     */
+    Orders approveOrder(Long orderId, Long employeeId);
 }

--- a/src/main/java/io/github/serhiiklym/appliance_store/service/impl/ApplianceServiceImpl.java
+++ b/src/main/java/io/github/serhiiklym/appliance_store/service/impl/ApplianceServiceImpl.java
@@ -1,7 +1,6 @@
 package io.github.serhiiklym.appliance_store.service.impl;
 
 import io.github.serhiiklym.appliance_store.error.DuplicateApplianceNameException;
-import io.github.serhiiklym.appliance_store.error.DuplicateManufacturerNameException;
 import io.github.serhiiklym.appliance_store.error.NotFoundException;
 import io.github.serhiiklym.appliance_store.model.Appliance;
 import io.github.serhiiklym.appliance_store.model.Category;
@@ -66,9 +65,6 @@ public class ApplianceServiceImpl implements ApplianceService {
                     String.format(Locale.ROOT, "Appliance name '%s' already exists", trimmedName)
             );
         }
-//        Manufacturer manufacturer = manufacturerRepository.findById(manufacturerId)
-//                .orElseThrow(() -> new NotFoundException("Creating appliance failed: Manufacturer not found with ID: " + manufacturerId));
-
 
         var trimmedModel = trimInputString(model);
         var trimmedProps = trimInputString(props);

--- a/src/main/java/io/github/serhiiklym/appliance_store/service/impl/OrderServiceImpl.java
+++ b/src/main/java/io/github/serhiiklym/appliance_store/service/impl/OrderServiceImpl.java
@@ -1,4 +1,153 @@
 package io.github.serhiiklym.appliance_store.service.impl;
 
-public class OrderServiceImpl {
+import io.github.serhiiklym.appliance_store.error.DuplicateOrderIdException;
+import io.github.serhiiklym.appliance_store.error.NotFoundException;
+import io.github.serhiiklym.appliance_store.error.OrderIsApprovedAndClosedToModificationsException;
+import io.github.serhiiklym.appliance_store.model.Appliance;
+import io.github.serhiiklym.appliance_store.model.Client;
+import io.github.serhiiklym.appliance_store.model.OrderRow;
+import io.github.serhiiklym.appliance_store.model.Orders;
+import io.github.serhiiklym.appliance_store.repository.ApplianceRepository;
+import io.github.serhiiklym.appliance_store.repository.ClientRepository;
+import io.github.serhiiklym.appliance_store.repository.OrderRowRepository;
+import io.github.serhiiklym.appliance_store.repository.OrdersRepository;
+import io.github.serhiiklym.appliance_store.service.OrderService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.HashSet;
+import java.util.Locale;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+public class OrderServiceImpl implements OrderService {
+
+    private final ClientRepository clientRepository;
+    private final OrdersRepository ordersRepository;
+    private final ApplianceRepository applianceRepository;
+    private final OrderRowRepository orderRowRepository;
+
+    public OrderServiceImpl(ClientRepository clientRepository, OrdersRepository ordersRepository, ApplianceRepository applianceRepository, OrderRowRepository orderRowRepository) {
+        this.clientRepository = clientRepository;
+        this.ordersRepository = ordersRepository;
+        this.applianceRepository = applianceRepository;
+        this.orderRowRepository = orderRowRepository;
+    }
+
+    @Override
+    public Page<Orders> list(Pageable pageable) {
+        return null;
+    }
+
+    @Override
+    public Page<Orders> listByClient(Long clientId, Pageable pageable) {
+        return null;
+    }
+
+    @Override
+    public Page<Orders> listByApproved(boolean approved, Pageable pageable) {
+        return null;
+    }
+
+    @Override
+    public BigDecimal getTotal(Long orderId) {
+        return null;
+    }
+
+    @Override
+    @Transactional
+    public Orders createOrder(Long clientId) {
+        Client client = clientRepository.findById(clientId)
+                .orElseThrow(() -> new NotFoundException("Client not found with ID: " + clientId));
+        log.debug("Creating an Order for client ID={}", clientId);
+        Orders order = new Orders();
+        order.setClient(client);
+        order.setApproved(false);
+        if (order.getOrderRowSet() == null) {
+            order.setOrderRowSet(new HashSet<>());
+        }
+
+        try {
+            Orders saved = ordersRepository.save(order);
+            log.info("Created order id={}, client card={}", saved.getId(), saved.getClient().getCard());
+            return saved;
+        } catch (DataIntegrityViolationException e) {
+            log.warn("Duplicate order on create with client ID={}", clientId, e);
+            throw new DuplicateOrderIdException(
+                    String.format(Locale.ROOT, "Order id is already exists for client '%d'", clientId)
+            );
+        }
+    }
+
+    @Override
+    @Transactional
+    public Orders addRow(Long orderId, Long applianceId, Long qty) {
+        if (qty == null || qty <= 0) {
+            throw new IllegalArgumentException("Quantity must be a positive integer");
+        }
+
+        Orders order = ordersRepository.findById(orderId)
+                .orElseThrow(() -> new NotFoundException("Order not found with ID: " + orderId));
+
+        if (Boolean.TRUE.equals(order.getApproved())) throw new OrderIsApprovedAndClosedToModificationsException(orderId);
+
+        Appliance appliance = applianceRepository.findById(applianceId)
+                .orElseThrow(() -> new NotFoundException("Appliance not found with ID: " + applianceId));
+
+        if (order.getOrderRowSet() == null) {
+            order.setOrderRowSet(new HashSet<>());
+        }
+
+        // Merge: if the appliance is already in the order -> increase quantity
+        OrderRow row = order.getOrderRowSet().stream()
+                .filter(r -> r.getAppliance() != null
+                        && r.getAppliance().getId().equals(applianceId))
+                .findFirst()
+                .orElse(null);
+
+        if (row == null) {
+            row = new OrderRow();
+            row.setOrder(order);                                    // owning side (FK lives on child)
+            row.setAppliance(appliance);
+            row.setNumber(qty);
+            row.setAmount(calcAmount(appliance.getPrice(), qty));
+            order.getOrderRowSet().add(row);                        // inverse side
+        } else {
+            long newQty = row.getNumber() + qty;
+            row.setNumber(newQty);
+            row.setAmount(calcAmount(appliance.getPrice(), newQty));
+        }
+
+        return ordersRepository.save(order);
+    }
+
+    @Override
+    public Orders updateRowQuantity(Long orderId, Long rowId, int qty) {
+        return null;
+    }
+
+    @Override
+    public void removeRow(Long orderId, Long rowId) {
+
+    }
+
+    @Override
+    public Orders approveOrder(Long orderId, Long employeeId) {
+        return null;
+    }
+
+    // -- helpers --
+    private static BigDecimal calcAmount(BigDecimal unitPrice, long qty) {
+        // Currency math with explicit scale and rounding
+        return unitPrice
+                .multiply(BigDecimal.valueOf(qty))
+                .setScale(2, RoundingMode.HALF_UP);
+    }
 }

--- a/src/test/java/io/github/serhiiklym/appliance_store/model/TestConstants.java
+++ b/src/test/java/io/github/serhiiklym/appliance_store/model/TestConstants.java
@@ -73,7 +73,7 @@ public class TestConstants {
 
     static class OrderRow {
         public static final String CLASS_NAME = "OrderRow";
-        public static final int CLASS_COUNT_FIELDS = 4;
+        public static final int CLASS_COUNT_FIELDS = 5;
         public static final int CLASS_COUNT_CONSTRUCTORS = 2;
         public static final int PARAMETERS_IN_CONSTRUCTOR_WITH_PARAMETERS = CLASS_COUNT_FIELDS;
     }

--- a/src/test/java/io/github/serhiiklym/appliance_store/service/impl/OrderServiceImplTest.java
+++ b/src/test/java/io/github/serhiiklym/appliance_store/service/impl/OrderServiceImplTest.java
@@ -58,14 +58,17 @@ class OrderServiceImplTest {
         @DisplayName("creates draft order for an existing client")
         void createsDraftOrder() {
 
-            when(ordersRepository.save(any(Orders.class))).thenAnswer(inv -> {
-                Orders o = inv.getArgument(0);
-                o.setId(555L);          // simulate DB-generated PK
-                return o;
-            });
-
             Long clientId = 101L;
-            when(clientRepository.findById(clientId)).thenReturn(Optional.of(client(clientId)));
+            when(clientRepository.findById(clientId))
+                    .thenReturn(Optional.of(client(clientId)));
+
+            when(ordersRepository.save(any(Orders.class)))
+                    .thenAnswer(inv -> {
+                        Orders o = inv.getArgument(0);
+                        o.setId(555L);           // simulate generated PK
+                        return o;
+                    });
+
 
             Orders saved = service.createOrder(clientId);
 
@@ -75,8 +78,8 @@ class OrderServiceImplTest {
             assertThat(saved.getOrderRowSet()).isNotNull();
             assertThat(saved.getOrderRowSet()).isEmpty();
 
-            // Verify we attempted to persist
             verify(ordersRepository, atLeastOnce()).save(any());
+            verify(ordersRepository, never()).saveAndFlush(any());
         }
 
         @Test

--- a/src/test/java/io/github/serhiiklym/appliance_store/service/impl/OrderServiceImplTest.java
+++ b/src/test/java/io/github/serhiiklym/appliance_store/service/impl/OrderServiceImplTest.java
@@ -1,0 +1,204 @@
+package io.github.serhiiklym.appliance_store.service.impl;
+
+import io.github.serhiiklym.appliance_store.error.NotFoundException;
+
+import io.github.serhiiklym.appliance_store.error.OrderIsApprovedAndClosedToModificationsException;
+import io.github.serhiiklym.appliance_store.model.Appliance;
+import io.github.serhiiklym.appliance_store.model.OrderRow;
+import io.github.serhiiklym.appliance_store.model.Orders;
+import io.github.serhiiklym.appliance_store.repository.ApplianceRepository;
+import io.github.serhiiklym.appliance_store.repository.ClientRepository;
+import io.github.serhiiklym.appliance_store.repository.OrdersRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+
+import static io.github.serhiiklym.appliance_store.service.impl.util.TestAppliances.appliance;
+import static io.github.serhiiklym.appliance_store.service.impl.util.TestClients.client;
+import static io.github.serhiiklym.appliance_store.service.impl.util.TestOrders.draftOrder;
+import static io.github.serhiiklym.appliance_store.service.impl.util.TestOrders.rowFor;
+import static java.math.RoundingMode.HALF_UP;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = org.mockito.quality.Strictness.LENIENT)
+class OrderServiceImplTest {
+
+    @Mock private ClientRepository clientRepository;
+    @Mock private OrdersRepository ordersRepository;
+    @Mock private ApplianceRepository applianceRepository;
+
+    @InjectMocks
+    private OrderServiceImpl service;
+
+    @BeforeEach
+    void stubSaveVariants() {
+        // Allow either save(..) or saveAndFlush(..) internally
+        when(ordersRepository.save(any(Orders.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(ordersRepository.saveAndFlush(any(Orders.class))).thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    @Nested
+    class CreateOrderTests {
+
+        @Test
+        @DisplayName("creates draft order for an existing client")
+        void createsDraftOrder() {
+
+            when(ordersRepository.save(any(Orders.class))).thenAnswer(inv -> {
+                Orders o = inv.getArgument(0);
+                o.setId(555L);          // simulate DB-generated PK
+                return o;
+            });
+
+            Long clientId = 101L;
+            when(clientRepository.findById(clientId)).thenReturn(Optional.of(client(clientId)));
+
+            Orders saved = service.createOrder(clientId);
+
+            assertThat(saved.getId()).isNotNull();          // set by stub
+            assertThat(saved.getApproved()).isFalse();
+            assertThat(saved.getClient().getId()).isEqualTo(clientId);
+            assertThat(saved.getOrderRowSet()).isNotNull();
+            assertThat(saved.getOrderRowSet()).isEmpty();
+
+            // Verify we attempted to persist
+            verify(ordersRepository, atLeastOnce()).save(any());
+        }
+
+        @Test
+        @DisplayName("throws NotFoundException when client is missing")
+        void throwsWhenClientMissing() {
+            Long clientId = 909L;
+            when(clientRepository.findById(clientId)).thenReturn(Optional.empty());
+
+            assertThrows(NotFoundException.class, () -> service.createOrder(clientId));
+
+            verify(ordersRepository, never()).save(any());
+            verify(ordersRepository, never()).saveAndFlush(any());
+        }
+    }
+
+    @Nested
+    class AddRowTests {
+
+        @Test
+        @DisplayName("adds a new row when appliance not present")
+        void addsNewRow() {
+            Long orderId = 201L, applId = 301L;
+            Orders order = draftOrder(orderId, client(77L));
+            Appliance appl = appliance(applId, new BigDecimal("19.99"));
+
+            when(ordersRepository.findById(orderId)).thenReturn(Optional.of(order));
+            when(applianceRepository.findById(applId)).thenReturn(Optional.of(appl));
+
+            Orders updated = service.addRow(orderId, applId, 3L);
+
+            assertThat(updated.getOrderRowSet()).hasSize(1);
+            OrderRow r = updated.getOrderRowSet().iterator().next();
+            assertThat(r.getAppliance().getId()).isEqualTo(applId);
+            assertThat(r.getNumber()).isEqualTo(3L); // assuming NUMBER == quantity
+            assertThat(r.getAmount()).isEqualByComparingTo(new BigDecimal("59.97").setScale(2, HALF_UP));
+
+            verify(ordersRepository, atLeastOnce()).save(any(Orders.class));
+        }
+
+        @Test
+        @DisplayName("merges quantity when same appliance already present")
+        void mergesQuantity() {
+            Long orderId = 202L, applId = 302L;
+            Orders order = draftOrder(orderId, client(88L));
+            Appliance appl = appliance(applId, new BigDecimal("10.00"));
+
+            // existing row qty=2, amount=20.00
+            order.getOrderRowSet().add(rowFor(appl, 2L, new BigDecimal("20.00")));
+
+            when(ordersRepository.findById(orderId)).thenReturn(Optional.of(order));
+            when(applianceRepository.findById(applId)).thenReturn(Optional.of(appl));
+
+            Orders updated = service.addRow(orderId, applId, 3L);
+
+            assertThat(updated.getOrderRowSet()).hasSize(1); // merged, not duplicated
+            OrderRow r = updated.getOrderRowSet().iterator().next();
+            assertThat(r.getNumber()).isEqualTo(5L);
+            assertThat(r.getAmount()).isEqualByComparingTo(new BigDecimal("50.00").setScale(2, HALF_UP));
+        }
+
+        @Test
+        @DisplayName("rejects non-positive quantity")
+        void rejectsNonPositiveQty() {
+            Long orderId = 203L, applId = 303L;
+
+            assertThrows(IllegalArgumentException.class, () -> service.addRow(orderId, applId, 0L));
+            assertThrows(IllegalArgumentException.class, () -> service.addRow(orderId, applId, -1L));
+
+            verifyNoInteractions(applianceRepository);
+            // ordersRepository may be touched before qty validation depending on your implementation;
+            // if you validate first, then also verifyNoInteractions(ordersRepository)
+        }
+
+        @Test
+        @DisplayName("throws when order not found")
+        void throwsWhenOrderMissing() {
+            when(ordersRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+            assertThrows(NotFoundException.class, () -> service.addRow(1L, 2L, 1L));
+            verify(applianceRepository, never()).findById(anyLong());
+        }
+
+        @Test
+        @DisplayName("throws when appliance not found")
+        void throwsWhenApplianceMissing() {
+            Long orderId = 204L;
+            Orders order = draftOrder(orderId, client(99L));
+            when(ordersRepository.findById(orderId)).thenReturn(Optional.of(order));
+            when(applianceRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+            assertThrows(NotFoundException.class, () -> service.addRow(orderId, 999L, 1L));
+        }
+
+        @Test
+        @DisplayName("rejects add when order is approved")
+        void rejectsWhenApproved() {
+            Long orderId = 205L, applId = 305L;
+            Orders order = draftOrder(orderId, client(11L));
+            order.setApproved(true);
+
+            when(ordersRepository.findById(orderId)).thenReturn(Optional.of(order));
+
+            assertThrows(OrderIsApprovedAndClosedToModificationsException.class,
+                    () -> service.addRow(orderId, applId, 1L));
+            verify(applianceRepository, never()).findById(anyLong());
+            verify(ordersRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("rounds HALF_UP to scale 2")
+        void roundsHalfUp() {
+            Long orderId = 206L, applId = 306L;
+            Orders order = draftOrder(orderId, client(12L));
+            Appliance appl = appliance(applId, new BigDecimal("19.995")); // boundary
+
+            when(ordersRepository.findById(orderId)).thenReturn(Optional.of(order));
+            when(applianceRepository.findById(applId)).thenReturn(Optional.of(appl));
+
+            Orders updated = service.addRow(orderId, applId, 1L);
+
+            OrderRow r = updated.getOrderRowSet().iterator().next();
+            assertThat(r.getAmount()).isEqualByComparingTo(new BigDecimal("20.00"));
+        }
+    }
+}

--- a/src/test/java/io/github/serhiiklym/appliance_store/service/impl/OrderServiceJpaSliceTest.java
+++ b/src/test/java/io/github/serhiiklym/appliance_store/service/impl/OrderServiceJpaSliceTest.java
@@ -1,0 +1,163 @@
+package io.github.serhiiklym.appliance_store.service.impl;
+
+import io.github.serhiiklym.appliance_store.error.OrderIsApprovedAndClosedToModificationsException;
+import io.github.serhiiklym.appliance_store.model.*;
+import io.github.serhiiklym.appliance_store.repository.*;
+import io.github.serhiiklym.appliance_store.service.OrderService;
+import io.github.serhiiklym.appliance_store.service.impl.util.TestClients;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import jakarta.persistence.EntityManager;
+import java.math.BigDecimal;
+
+import static io.github.serhiiklym.appliance_store.service.impl.util.TestAppliances.persistApplianceAllFields;
+import static io.github.serhiiklym.appliance_store.service.impl.util.TestClients.makeValidClient;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * @DataJpaTest boots JPA, repositories, and an embedded DB.
+ * We @Import the service to exercise real SQL + mappings.
+ */
+@DataJpaTest
+@Import(OrderServiceImpl.class)
+class OrderServiceJpaSliceTest {
+
+    @Autowired private OrderService orderService; // the real service under test
+    @Autowired private OrdersRepository ordersRepository;
+    @Autowired private OrderRowRepository orderRowRepository;
+    @Autowired private ClientRepository clientRepository;
+    @Autowired private ApplianceRepository applianceRepository;
+    @Autowired private ManufacturerRepository manufacturerRepository;
+    @Autowired private EntityManager em;
+
+    private Client persistClient(String name) {
+        Client c = new Client();
+        c.setName(name);
+        return clientRepository.save(c);
+    }
+
+    private Appliance persistAppliance(String name, String price) {
+        Appliance a = new Appliance();
+        a.setName(name);
+        a.setPrice(new BigDecimal(price));
+        return applianceRepository.save(a);
+    }
+
+    private void flushAndClear() {
+        em.flush();
+        em.clear(); // ensure we read back from DB, not from the persistence context
+    }
+
+    @Test
+    @DisplayName("createOrder persists and returns a managed entity with generated ID")
+    void createOrder_persists_and_generates_id() {
+        Client client = clientRepository.saveAndFlush(makeValidClient("Alice"));
+
+        Orders saved = orderService.createOrder(client.getId());
+
+        assertThat(saved.getId()).as("ID should be generated").isNotNull();
+        assertThat(saved.getApproved()).isFalse();
+        assertThat(saved.getClient().getId()).isEqualTo(client.getId());
+        assertThat(saved.getOrderRowSet()).isNotNull().isEmpty();
+
+        flushAndClear();
+
+        Orders reloaded = ordersRepository.findById(saved.getId()).orElseThrow();
+        assertThat(reloaded.getApproved()).isFalse();
+        assertThat(reloaded.getClient().getId()).isEqualTo(client.getId());
+        assertThat(reloaded.getOrderRowSet()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("addRow persists child rows via cascade and computes amount with HALF_UP to 2 decimals")
+    void addRow_persists_row_via_cascade_and_rounds() {
+        // Arrange: persist valid client and appliance
+        Client client = clientRepository.saveAndFlush(TestClients.makeValidClient("Bob"));
+        Appliance appl = persistApplianceAllFields(
+                applianceRepository, manufacturerRepository,
+                "BrandX", "Kettle", "KT-1", "19.995",
+                Category.SMALL, PowerType.AC220
+        );
+
+        // Persist order (gets an ID)
+        Orders order = orderService.createOrder(client.getId());
+        // If createOrder() uses save(...), ensure the row is in DB before addRow():
+        ordersRepository.flush();
+
+        // Sanity guards
+        assertThat(order.getId()).isNotNull();
+        assertThat(appl.getId()).isNotNull();
+
+        // Act
+        orderService.addRow(order.getId(), appl.getId(), 1L);
+
+        flushAndClear();
+
+        // Assert
+        Orders reloaded = ordersRepository.findById(order.getId()).orElseThrow();
+        assertThat(reloaded.getOrderRowSet()).hasSize(1);
+        OrderRow row = reloaded.getOrderRowSet().iterator().next();
+        assertThat(row.getAppliance().getId()).isEqualTo(appl.getId());
+        assertThat(row.getNumber()).isEqualTo(1L);
+        assertThat(row.getAmount()).isEqualByComparingTo(new java.math.BigDecimal("20.00"));
+    }
+
+
+    @Test
+    @DisplayName("removing a row and saving the order deletes the child via orphanRemoval (if configured)")
+    void orphanRemoval_removes_child() {
+        Client client = clientRepository.saveAndFlush(makeValidClient("Carol"));
+        Appliance appl = persistApplianceAllFields(
+                applianceRepository, manufacturerRepository,
+                "BrandX", "Toaster", "KT-1", "25.00",
+                Category.SMALL, PowerType.AC110);
+        //Appliance appl = persistAppliance("Toaster", "25.00");
+        Orders order = orderService.createOrder(client.getId());
+        orderService.addRow(order.getId(), appl.getId(), 2L);
+
+        flushAndClear();
+
+        // load fresh aggregate from DB
+        Orders reloaded = ordersRepository.findById(order.getId()).orElseThrow();
+        assertThat(reloaded.getOrderRowSet()).hasSize(1);
+        OrderRow row = reloaded.getOrderRowSet().iterator().next();
+        Long rowId = row.getId(); // requires @Id on OrderRow
+
+        // remove child from collection and save the parent
+        reloaded.getOrderRowSet().remove(row);
+        ordersRepository.save(reloaded);
+
+        flushAndClear();
+
+        // expect the child row to be gone if orphanRemoval=true
+        boolean exists = orderRowRepository.findById(rowId).isPresent();
+        assertThat(exists)
+                .as("OrderRow should be deleted when removed from parent collection (orphanRemoval=true)")
+                .isFalse();
+    }
+
+    @Test
+    @DisplayName("cannot add rows to an approved order (domain guard)")
+    void addRow_rejected_when_order_approved() {
+        Client client = clientRepository.saveAndFlush(makeValidClient("Dave"));
+        Appliance appl = persistApplianceAllFields(
+                applianceRepository, manufacturerRepository,
+                "BrandX", "Microwave", "KT-1", "100.00",
+                Category.BIG, PowerType.AC110);
+        //Appliance appl = persistAppliance("Microwave", "100.00");
+        Orders order = orderService.createOrder(client.getId());
+
+        // flip approved and persist (simulates approval; replace with approveOrder() when implemented)
+        order.setApproved(true);
+        ordersRepository.save(order);
+        flushAndClear();
+
+        assertThrows(OrderIsApprovedAndClosedToModificationsException.class,
+                () -> orderService.addRow(order.getId(), appl.getId(), 1L));
+    }
+}

--- a/src/test/java/io/github/serhiiklym/appliance_store/service/impl/util/TestAppliances.java
+++ b/src/test/java/io/github/serhiiklym/appliance_store/service/impl/util/TestAppliances.java
@@ -1,6 +1,11 @@
 package io.github.serhiiklym.appliance_store.service.impl.util;
 
 import io.github.serhiiklym.appliance_store.model.Appliance;
+import io.github.serhiiklym.appliance_store.model.Category;
+import io.github.serhiiklym.appliance_store.model.Manufacturer;
+import io.github.serhiiklym.appliance_store.model.PowerType;
+import io.github.serhiiklym.appliance_store.repository.ApplianceRepository;
+import io.github.serhiiklym.appliance_store.repository.ManufacturerRepository;
 
 import java.math.BigDecimal;
 
@@ -13,5 +18,43 @@ public final class TestAppliances {
         a.setName("Appliance " + id);
         a.setPrice(price);
         return a;
+    }
+    /** Build a valid, non-persisted Appliance (fills all commonly @NotNull/@NotBlank fields). */
+    public static Appliance makeValidAppliance(
+            String name,
+            String model,
+            String price,
+            Category category,
+            PowerType powerType,
+            Manufacturer manufacturer
+    ) {
+        Appliance a = new Appliance();
+        a.setName(name);
+        a.setModel(model);
+        a.setCharacteristic("specs");
+        a.setDescription("test description");
+        a.setPower(100);
+        a.setPrice(new BigDecimal(price));
+        a.setCategory(category);
+        a.setPowerType(powerType);
+        a.setManufacturer(manufacturer);
+        return a;
+    }
+
+    /** Convenience: create + persist manufacturer, then create + persist appliance. */
+    public static Appliance persistApplianceAllFields(
+            ApplianceRepository applianceRepo,
+            ManufacturerRepository manufacturerRepo,
+            String manufacturerName,
+            String name,
+            String model,
+            String price,
+            Category category,
+            PowerType powerType
+    ) {
+        Manufacturer m = TestManufacturers.persistManufacturer(manufacturerRepo, manufacturerName);
+        return applianceRepo.saveAndFlush(
+                makeValidAppliance(name, model, price, category, powerType, m)
+        );
     }
 }

--- a/src/test/java/io/github/serhiiklym/appliance_store/service/impl/util/TestAppliances.java
+++ b/src/test/java/io/github/serhiiklym/appliance_store/service/impl/util/TestAppliances.java
@@ -1,0 +1,17 @@
+package io.github.serhiiklym.appliance_store.service.impl.util;
+
+import io.github.serhiiklym.appliance_store.model.Appliance;
+
+import java.math.BigDecimal;
+
+public final class TestAppliances {
+    private TestAppliances() {}
+
+    public static Appliance appliance(Long id, BigDecimal price) {
+        Appliance a = new Appliance();
+        a.setId(id);
+        a.setName("Appliance " + id);
+        a.setPrice(price);
+        return a;
+    }
+}

--- a/src/test/java/io/github/serhiiklym/appliance_store/service/impl/util/TestClients.java
+++ b/src/test/java/io/github/serhiiklym/appliance_store/service/impl/util/TestClients.java
@@ -1,9 +1,11 @@
 package io.github.serhiiklym.appliance_store.service.impl.util;
 
 import io.github.serhiiklym.appliance_store.model.Client;
+import io.github.serhiiklym.appliance_store.repository.ClientRepository;
 
 public final class TestClients {
     private TestClients() {}
+
 
     public static Client client(Long id) {
         Client c = new Client();
@@ -11,5 +13,23 @@ public final class TestClients {
         c.setName("Test Client " + id);
         return c;
     }
+
+    /** Build a valid Client that passes Bean Validation, not persisted. */
+    public static Client makeValidClient(String name) {
+        Client c = new Client();
+        c.setName(name);
+        c.setEmail(name.toLowerCase().replaceAll("\\s+", "") + "@example.com");
+        // long-ish string to satisfy @NotBlank/@Size; any dummy hash-like string is fine
+        c.setPassword("$2a$10$aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        // satisfy @NotBlank/@Pattern if present
+        c.setCard("4242424242424242");
+        return c;
+    }
+
+    /** Convenience: build + persist using the repository passed in. */
+    public static Client persistClientAllFields(ClientRepository repo, String name) {
+        return repo.saveAndFlush(makeValidClient(name));
+    }
+
 }
 

--- a/src/test/java/io/github/serhiiklym/appliance_store/service/impl/util/TestClients.java
+++ b/src/test/java/io/github/serhiiklym/appliance_store/service/impl/util/TestClients.java
@@ -1,0 +1,15 @@
+package io.github.serhiiklym.appliance_store.service.impl.util;
+
+import io.github.serhiiklym.appliance_store.model.Client;
+
+public final class TestClients {
+    private TestClients() {}
+
+    public static Client client(Long id) {
+        Client c = new Client();
+        c.setId(id);
+        c.setName("Test Client " + id);
+        return c;
+    }
+}
+

--- a/src/test/java/io/github/serhiiklym/appliance_store/service/impl/util/TestManufacturers.java
+++ b/src/test/java/io/github/serhiiklym/appliance_store/service/impl/util/TestManufacturers.java
@@ -1,0 +1,20 @@
+package io.github.serhiiklym.appliance_store.service.impl.util;
+
+import io.github.serhiiklym.appliance_store.model.Manufacturer;
+import io.github.serhiiklym.appliance_store.repository.ManufacturerRepository;
+
+public final class TestManufacturers {
+    private TestManufacturers() {}
+
+    /** Build a valid, non-persisted Manufacturer. Add more fields if your entity requires them. */
+    public static Manufacturer makeValidManufacturer(String name) {
+        Manufacturer m = new Manufacturer();
+        m.setName(name);
+        return m;
+    }
+
+    /** Persist a valid manufacturer using the repo provided by the test. */
+    public static Manufacturer persistManufacturer(ManufacturerRepository repo, String name) {
+        return repo.saveAndFlush(makeValidManufacturer(name));
+    }
+}

--- a/src/test/java/io/github/serhiiklym/appliance_store/service/impl/util/TestOrders.java
+++ b/src/test/java/io/github/serhiiklym/appliance_store/service/impl/util/TestOrders.java
@@ -1,0 +1,31 @@
+package io.github.serhiiklym.appliance_store.service.impl.util;
+
+import io.github.serhiiklym.appliance_store.model.Appliance;
+import io.github.serhiiklym.appliance_store.model.Client;
+import io.github.serhiiklym.appliance_store.model.OrderRow;
+import io.github.serhiiklym.appliance_store.model.Orders;
+
+import java.math.BigDecimal;
+import java.util.HashSet;
+
+public final class TestOrders {
+    private TestOrders() {}
+
+    public static Orders draftOrder(Long id, Client client) {
+        Orders o = new Orders();
+        o.setId(id);
+        o.setClient(client);
+        o.setApproved(false);
+        o.setOrderRowSet(new HashSet<>());
+        return o;
+    }
+
+    public static OrderRow rowFor(Appliance appliance, long qty, BigDecimal amount) {
+        OrderRow r = new OrderRow();
+        r.setAppliance(appliance);
+        r.setNumber(qty); // assuming NUMBER is the quantity column
+        r.setAmount(amount);
+        return r;
+    }
+}
+

--- a/src/test/java/io/github/serhiiklym/appliance_store/service/impl/util/TestOrders.java
+++ b/src/test/java/io/github/serhiiklym/appliance_store/service/impl/util/TestOrders.java
@@ -4,8 +4,11 @@ import io.github.serhiiklym.appliance_store.model.Appliance;
 import io.github.serhiiklym.appliance_store.model.Client;
 import io.github.serhiiklym.appliance_store.model.OrderRow;
 import io.github.serhiiklym.appliance_store.model.Orders;
+import io.github.serhiiklym.appliance_store.repository.OrderRowRepository;
+import io.github.serhiiklym.appliance_store.repository.OrdersRepository;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.HashSet;
 
 public final class TestOrders {
@@ -26,6 +29,47 @@ public final class TestOrders {
         r.setNumber(qty); // assuming NUMBER is the quantity column
         r.setAmount(amount);
         return r;
+    }
+
+    /** Build a valid draft order (not persisted). */
+    public static Orders makeDraftOrder(Client client) {
+        Orders o = new Orders();
+        o.setClient(client);
+        o.setApproved(false);
+        o.setOrderRowSet(new HashSet<>());
+        // If your model has an employee approver field, leave it null for drafts.
+        return o;
+    }
+
+    /** Persist a draft order using the repo provided by the test. */
+    public static Orders persistDraftOrder(OrdersRepository repo, Client client) {
+        return repo.saveAndFlush(makeDraftOrder(client));
+    }
+
+    /**
+     * Create a new OrderRow for a given appliance & qty, attach it to the order,
+     * and keep both sides of the association in sync.
+     *  */
+    public static OrderRow attachRow(Orders order, Appliance appliance, long qty) {
+        OrderRow row = new OrderRow();
+        row.setOrder(order);                 // owning side set
+        row.setAppliance(appliance);
+        row.setNumber(qty);
+        row.setAmount(appliance.getPrice()
+                .multiply(BigDecimal.valueOf(qty))
+                .setScale(2, RoundingMode.HALF_UP));
+        order.getOrderRowSet().add(row);     // inverse side set
+        return row;
+    }
+
+    /** Persist the parent order; with cascade PERSIST/MERGE this will save rows too. */
+    public static Orders saveGraph(OrdersRepository repo, Orders order) {
+        return repo.saveAndFlush(order);
+    }
+
+    /** If you don't have cascade, persist the row explicitly. */
+    public static OrderRow persistRow(OrderRowRepository rowRepo, OrderRow row) {
+        return rowRepo.saveAndFlush(row);
     }
 }
 


### PR DESCRIPTION
**Summary**
Introduce the Orders slice foundation: repositories for Orders/OrderRow and the OrderService interface. No schema changes; we use the existing boolean approved flag.

**What’s included**
	- OrdersRepository with paged finders (by client, by approved) and ownership helpers.
	- OrderRowRepository with duplicate lookup, row deletion by order, and list by order.
	- OrderService contract covering: create order, add row, update row qty, remove row, approve order, list/read totals.

**Business rules codified**
	- Adding the same appliance again merges quantities in the same order.
	- updateRowQuantity(..., 0) auto-deletes the row.
	- No edits allowed after an order is approved.
	- Approving an empty order is forbidden.
	- Pagination supported via Pageable where applicable.